### PR TITLE
Use namespaced GlobalVarConfig

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -127,7 +127,7 @@
 		}
 	},
 	"ConfigRegistry": {
-		"thumbro": "GlobalVarConfig::newInstance"
+		"thumbro": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
The non-namespaced class alias was deprecated in MW 1.41. See also https://phabricator.wikimedia.org/T402038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a configuration loading issue by updating a registry entry to use a fully qualified, namespaced reference, improving reliability across environments.

* **Chores**
  * Aligned configuration references with current platform conventions to enhance compatibility and maintainability.

No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->