### PR TITLE
Fix fatal error when image request fails in SpecialThumbroTest & i18n updates

### DIFF
--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -1,0 +1,30 @@
+{
+	"@metadata": {
+		"authors": [
+			"Zorua_Fox"
+		]
+	},
+	"thumbrotest": "Thumbro 测试页面",
+	"thumbro-desc": "改进并扩展 MediaWiki 中的缩略图功能",
+	"thumbro-invalid-file": "无法处理请求的文件。请检查该文件是否存在于此 wiki 上。",
+	"thumbro-invalid-width": "缩略图宽度应大于零且不大于文件宽度。",
+	"thumbro-invalid-sharpen": "锐化量应为大于零且小于五的数字。",
+	"thumbro-thumb-error": "libvips 无法使用给定参数生成缩略图。",
+	"thumbro-thumb-notscaled": "libvips 未缩放缩略图。",
+	"thumbro-form-legend": "参数",
+	"thumbro-form-width": "缩略图宽度：",
+	"thumbro-form-file": "此 wiki 上的文件：",
+	"thumbro-form-sharpen-radius": "锐化量：",
+	"thumbro-form-bilinear": "双线性缩放",
+	"thumbro-form-submit": "生成缩略图",
+	"thumbro-thumbs-legend": "生成的缩略图",
+	"thumbro-thumbs-help": "将鼠标悬停在缩略图上以比较缩略图。",
+	"thumbro-original-image": "原始",
+	"thumbro-normal-image": "当前",
+	"thumbro-thumbro-image": "Thumbro",
+	"thumbro-show-both": "显示两个缩略图",
+	"thumbro-show-default": "仅显示默认缩略图",
+	"thumbro-show-vips": "仅显示 libvips 缩略图",
+	"action-thumbro-test": "使用 libvips 缩放测试界面 [[Special:ThumbroTest]]",
+	"right-thumbro-test": "使用 libvips 缩放测试界面 [[Special:ThumbroTest]]"
+}

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -1,0 +1,30 @@
+{
+	"@metadata": {
+		"authors": [
+			"Zorua_Fox"
+		]
+	},
+	"thumbrotest": "Thumbro 測試頁面",
+	"thumbro-desc": "改進並擴充 MediaWiki 中的縮圖功能",
+	"thumbro-invalid-file": "無法處理請求的檔案。請檢查該檔案是否存在於此 wiki 上。",
+	"thumbro-invalid-width": "縮圖寬度應大於零且不大於檔案寬度。",
+	"thumbro-invalid-sharpen": "銳化量應為大於零且小於五的數字。",
+	"thumbro-thumb-error": "libvips 無法使用給定參數產生縮圖。",
+	"thumbro-thumb-notscaled": "libvips 未縮放縮圖。",
+	"thumbro-form-legend": "參數",
+	"thumbro-form-width": "縮圖寬度：",
+	"thumbro-form-file": "此 wiki 上的檔案：",
+	"thumbro-form-sharpen-radius": "銳化量：",
+	"thumbro-form-bilinear": "雙線性縮放",
+	"thumbro-form-submit": "產生縮圖",
+	"thumbro-thumbs-legend": "產生的縮圖",
+	"thumbro-thumbs-help": "將滑鼠懸停在縮圖上以比較縮圖。",
+	"thumbro-original-image": "原始",
+	"thumbro-normal-image": "目前",
+	"thumbro-thumbro-image": "Thumbro",
+	"thumbro-show-both": "顯示兩個縮圖",
+	"thumbro-show-default": "僅顯示預設縮圖",
+	"thumbro-show-vips": "僅顯示 libvips 縮圖",
+	"action-thumbro-test": "使用 libvips 縮放測試介面 [[Special:ThumbroTest]]",
+	"right-thumbro-test": "使用 libvips 縮放測試介面 [[Special:ThumbroTest]]"
+}

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -1,0 +1,30 @@
+{
+	"@metadata": {
+		"authors": [
+			"Zorua_Fox"
+		]
+	},
+	"thumbrotest": "Thumbro 测试页面",
+	"thumbro-desc": "改进并扩展 MediaWiki 中的缩略图功能",
+	"thumbro-invalid-file": "无法处理请求的文件。请检查该文件是否存在于此 wiki 上。",
+	"thumbro-invalid-width": "缩略图宽度应大于零且不大于文件宽度。",
+	"thumbro-invalid-sharpen": "锐化量应为大于零且小于五的数字。",
+	"thumbro-thumb-error": "libvips 无法使用给定参数生成缩略图。",
+	"thumbro-thumb-notscaled": "libvips 未缩放缩略图。",
+	"thumbro-form-legend": "参数",
+	"thumbro-form-width": "缩略图宽度：",
+	"thumbro-form-file": "此 wiki 上的文件：",
+	"thumbro-form-sharpen-radius": "锐化量：",
+	"thumbro-form-bilinear": "双线性缩放",
+	"thumbro-form-submit": "生成缩略图",
+	"thumbro-thumbs-legend": "生成的缩略图",
+	"thumbro-thumbs-help": "将鼠标悬停在缩略图上以比较缩略图。",
+	"thumbro-original-image": "原始",
+	"thumbro-normal-image": "当前",
+	"thumbro-thumbro-image": "Thumbro",
+	"thumbro-show-both": "显示两个缩略图",
+	"thumbro-show-default": "仅显示默认缩略图",
+	"thumbro-show-vips": "仅显示 libvips 缩略图",
+	"action-thumbro-test": "使用 libvips 缩放测试界面 [[Special:ThumbroTest]]",
+	"right-thumbro-test": "使用 libvips 缩放测试界面 [[Special:ThumbroTest]]"
+}

--- a/includes/SpecialThumbroTest.php
+++ b/includes/SpecialThumbroTest.php
@@ -245,6 +245,11 @@ class SpecialThumbroTest extends SpecialPage {
 		$images = [];
 		foreach ( $imageUrls as $type => $url ) {
 			$req = $this->getImageRequest( $url );
+
+			if ( !$req ) {
+				throw new \RuntimeException( "Failed to fetch image from $url" );
+			}
+
 			$image = new Imagick();
 			$image->readImageBlob( $req->getContent() );
 			$images[$type] = $image;


### PR DESCRIPTION
This pull request includes two major changes:

1. 65309b3 feat: add chinese i18n files
2. b7eb7ba fix: add error handling for failed image requests in SpecialThumbroTest

cc. @alistair3149 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added comprehensive Chinese language localization support including Simplified, Traditional, and standard Chinese variants for all application features and messaging

**Bug Fixes**
- Enhanced error handling in image operations to explicitly report failures when image retrieval is unsuccessful, replacing silent failures with informative error messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->