### PR TITLE
fix: resolve phpcs and phan failures

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,3 +1,9 @@
 <?php
 
-return require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.php';
+$cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.php';
+
+// Imagick is an optional PECL extension; provide stubs so Phan can type-check
+// Imagick code paths that are gated on extension_loaded( 'imagick' ).
+$cfg['autoload_internal_extension_signatures']['imagick'] = __DIR__ . '/stubs/imagick.phan_php';
+
+return $cfg;

--- a/.phan/stubs/imagick.phan_php
+++ b/.phan/stubs/imagick.phan_php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Phan stub for the optional Imagick PECL extension.
+ * Loaded via autoload_internal_extension_signatures in .phan/config.php so Phan can
+ * type-check Imagick code paths gated on extension_loaded( 'imagick' ).
+ *
+ * Only declares the surface used by this extension — extend as new Imagick calls are added.
+ */
+
+class Imagick {
+	public const FILTER_LANCZOS = 22;
+	public const METRIC_PEAKSIGNALTONOISERATIO = 8;
+	public const METRIC_PERCEPTUALHASH_ERROR = 9;
+	public const METRIC_STRUCTURAL_SIMILARITY_ERROR = 13;
+
+	public function __construct( $files = null ) {
+	}
+
+	public function readImageBlob( string $image, ?string $filename = null ): bool {
+	}
+
+	public function resizeImage(
+		int $columns,
+		int $rows,
+		int $filter,
+		float $blur,
+		bool $bestfit = false,
+		bool $legacy = false
+	): bool {
+	}
+
+	public function getImageWidth(): int {
+	}
+
+	public function getImageHeight(): int {
+	}
+
+	public function getImageMimeType(): string {
+	}
+
+	public function getImageLength(): int {
+	}
+
+	public function compareImages( Imagick $compare, int $metric ): array {
+	}
+
+	public static function getVersion(): array {
+	}
+}

--- a/includes/Hooks/MediaWikiHooks.php
+++ b/includes/Hooks/MediaWikiHooks.php
@@ -85,7 +85,7 @@ class MediaWikiHooks implements
 		$maxImageArea = $config->get( MainConfigNames::MaxImageArea );
 
 		/** @phan-suppress-next-line PhanTypeMismatchArgumentSuperType ImageHandler vs. MediaHandler */
-		if ( Utils::getOptions( $file->getHandler(), $file, $config ) !== false ) {
+		if ( Utils::getOptions( $file->getHandler(), $file, $config ) !== null ) {
 			wfDebug( "[Extension:Thumbro] Overriding wgMaxImageArea: $maxImageArea" );
 			$result = true;
 			return false;

--- a/includes/Hooks/ThumbroBeforeProduceHtmlHook.php
+++ b/includes/Hooks/ThumbroBeforeProduceHtmlHook.php
@@ -13,7 +13,7 @@ use MediaWiki\Extension\Thumbro\ThumbroThumbnailImage;
  */
 interface ThumbroBeforeProduceHtmlHook {
 	/**
-	 * @param ThumbroThumbnailImage $context
+	 * @param ThumbroThumbnailImage $thumbnail
 	 * @param array &$sources
 	 * @return bool|void True or no return value to continue or false to abort
 	 */

--- a/includes/MediaHandlers/ThumbroHandlerTrait.php
+++ b/includes/MediaHandlers/ThumbroHandlerTrait.php
@@ -6,6 +6,9 @@ namespace MediaWiki\Extension\Thumbro\MediaHandlers;
 use MediaWiki\Extension\Thumbro\ThumbroThumbnailImage;
 use TransformParameterError;
 
+/**
+ * @require-extends \TransformationalImageHandler
+ */
 trait ThumbroHandlerTrait {
 	/**
 	 * @inheritDoc
@@ -30,10 +33,13 @@ trait ThumbroHandlerTrait {
 	 * @inheritDoc
 	 */
 	public function doTransform( $image, $dstPath, $dstUrl, $params, $flags = 0 ) {
+		// @phan-suppress-next-line PhanTraitParentReference parent provided by @require-extends
 		if ( !( $flags & parent::TRANSFORM_LATER ) ) {
+			// @phan-suppress-next-line PhanTraitParentReference parent provided by @require-extends
 			return parent::doTransform( $image, $dstPath, $dstUrl, $params, $flags );
 		}
 
+		// @phan-suppress-next-line PhanUndeclaredMethod normaliseParams provided by @require-extends parent
 		if ( !$this->normaliseParams( $image, $params ) ) {
 			return new TransformParameterError( $params );
 		}

--- a/includes/SpecialThumbroTest.php
+++ b/includes/SpecialThumbroTest.php
@@ -282,7 +282,7 @@ class SpecialThumbroTest extends SpecialPage {
 			if ( defined( 'Imagick::METRIC_STRUCTURAL_SIMILARITY_ERROR' ) ) {
 				$info[$type]['SSIM'] = $image->compareImages(
 					$images['original'],
-					Imagick::METRIC_STRUCTURAL_SIMILARITY_ERROR
+					constant( 'Imagick::METRIC_STRUCTURAL_SIMILARITY_ERROR' )
 				)[1];
 			}
 		}

--- a/includes/SpecialThumbroTest.php
+++ b/includes/SpecialThumbroTest.php
@@ -88,7 +88,8 @@ class SpecialThumbroTest extends SpecialPage {
 		$request = $this->getRequest();
 		$this->setHeaders();
 
-		$isInternalRequest = $request->getHeader( 'X-Thumbro-Secret' ) === $this->getConfig()->get( MainConfigNames::SecretKey );
+		$secretKey = $this->getConfig()->get( MainConfigNames::SecretKey );
+		$isInternalRequest = $request->getHeader( 'X-Thumbro-Secret' ) === $secretKey;
 		$isUserAllowed = $this->userCanExecute( $this->getUser() );
 
 		if ( !$isUserAllowed && !$isInternalRequest ) {
@@ -215,25 +216,23 @@ class SpecialThumbroTest extends SpecialPage {
 				$infoHtml .= '</ul></div>';
 			}
 
-			$infoHtml = new HtmlSnippet( "<div style='display: grid; grid-template-columns:1fr 1fr 1fr; gap: 8px;'>$infoHtml</div>" );
-			$this->getOutput()->addHTML(
-				new PanelLayout( [
-					'expanded' => false,
-					'padded' => true,
-					'framed' => true,
-					'content' => [ $infoHtml ],
-				] )
+			$infoHtml = new HtmlSnippet(
+				"<div style='display: grid; grid-template-columns:1fr 1fr 1fr; gap: 8px;'>$infoHtml</div>"
 			);
-		}
-
-		$this->getOutput()->addHTML(
-			new PanelLayout( [
+			$this->getOutput()->addHTML( (string)( new PanelLayout( [
 				'expanded' => false,
 				'padded' => true,
 				'framed' => true,
-				'content' => [ $fieldset, $thumbs, $thumbsOrigCurr, $thumbsOrigThumbro ],
-			] )
-		);
+				'content' => [ $infoHtml ],
+			] ) ) );
+		}
+
+		$this->getOutput()->addHTML( (string)( new PanelLayout( [
+			'expanded' => false,
+			'padded' => true,
+			'framed' => true,
+			'content' => [ $fieldset, $thumbs, $thumbsOrigCurr, $thumbsOrigThumbro ],
+		] ) ) );
 
 		$this->getOutput()->addModules( [ 'ext.thumbro' ] );
 	}
@@ -273,12 +272,18 @@ class SpecialThumbroTest extends SpecialPage {
 
 			// ImageMagick 6.9.0+
 			if ( defined( 'Imagick::METRIC_PERCEPTUALHASH_ERROR' ) ) {
-				$info[$type]['Perceptual Hash'] = $image->compareImages( $images['original'], Imagick::METRIC_PERCEPTUALHASH_ERROR )[1];
+				$info[$type]['Perceptual Hash'] = $image->compareImages(
+					$images['original'],
+					Imagick::METRIC_PERCEPTUALHASH_ERROR
+				)[1];
 			}
 
 			// ImageMagick 7.0.7
 			if ( defined( 'Imagick::METRIC_STRUCTURAL_SIMILARITY_ERROR' ) ) {
-				$info[$type]['SSIM'] = $image->compareImages( $images['original'], Imagick::METRIC_STRUCTURAL_SIMILARITY_ERROR )[1];
+				$info[$type]['SSIM'] = $image->compareImages(
+					$images['original'],
+					Imagick::METRIC_STRUCTURAL_SIMILARITY_ERROR
+				)[1];
 			}
 		}
 		return $info;
@@ -289,8 +294,9 @@ class SpecialThumbroTest extends SpecialPage {
 	 */
 	private function getImageMetric( Imagick $image, string $metric ): ?string {
 		if ( defined( $metric ) ) {
-			return $image->compareImages( $image, $metric )[1];
+			return $image->compareImages( $image, constant( $metric ) )[1];
 		}
+		return null;
 	}
 
 	/**
@@ -312,7 +318,7 @@ class SpecialThumbroTest extends SpecialPage {
 	 */
 	private function humanFileSize( int $bytes, ?int $decimals = 2 ): string {
 		$size = [ 'B', 'KB', 'MB', 'GB', 'TB', 'PB' ];
-		$factor = floor( ( strlen( $bytes ) - 1 ) / 3 );
+		$factor = (int)floor( ( strlen( (string)$bytes ) - 1 ) / 3 );
 		return sprintf( "%.{$decimals}f %s",
 			$bytes / ( 1000 ** $factor ),
 			$size[$factor]
@@ -554,7 +560,7 @@ class SpecialThumbroTest extends SpecialPage {
 				'Expires: ' . gmdate( 'r ', time() + $thumbroTestExpiry )
 			] );
 		} else {
-			'@phan-var MediaTransformError $mto';
+			'@phan-var \MediaTransformError $mto';
 			$this->streamError( 500, $mto->getHtmlMsg() );
 		}
 

--- a/includes/ThumbroThumbnailImage.php
+++ b/includes/ThumbroThumbnailImage.php
@@ -162,7 +162,11 @@ class ThumbroThumbnailImage extends ThumbnailImage {
 			if ( !empty( $source['width'] ) && !empty( $attribs['width'] ) && $source['width'] !== $attribs['width'] ) {
 				$sourceAttribs['width'] = $source['width'];
 			}
-			if ( !empty( $source['height'] ) && !empty( $attribs['height'] ) && $source['height'] !== $attribs['height'] ) {
+			if (
+				!empty( $source['height'] ) &&
+				!empty( $attribs['height'] ) &&
+				$source['height'] !== $attribs['height']
+			) {
 				$sourceAttribs['height'] = $source['height'];
 			}
 

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -34,7 +34,7 @@ class Utils {
 			}
 
 			$library = $option['library'];
-			if ( !isset( $library ) || !isset( $libraries[$library] ) || !isset( $libraries[$library]['command'] ) ) {
+			if ( !isset( $libraries[$library] ) || !isset( $libraries[$library]['command'] ) ) {
 				continue;
 			}
 			$option['command'] = $libraries[$library]['command'];


### PR DESCRIPTION
## Summary
PHPCS and Phan were both failing on `main` after the recent CI workflow migration surfaced them. This PR fixes the underlying issues.

### Real bugs found
- **`MediaWikiHooks::onBitmapHandlerCheckImageArea`**: `Utils::getOptions()` returns `?array`, so the `!== false` check was always true and the area override fired for every file regardless of whether Thumbro would transform it. Changed to `!== null`.
- **`SpecialThumbroTest::humanFileSize`**: `strlen( int )` and array index by `float` (from `floor()`) — both PHP 8.1+ deprecations. Now casts to string for `strlen` and to int for the array index.
- **`SpecialThumbroTest::getImageMetric`**: passed a constant *name* string where `Imagick::compareImages()` wants the *value* int. Fixed via `constant()` lookup. (Phan only caught this once the new Imagick stub was in place.)
- **OOUI `PanelLayout` -> `OutputPage::addHTML()`**: addHTML expects string; now cast to string.
- **`@phan-var MediaTransformError $mto`**: was resolving to the wrong namespace (`\MediaWiki\Extension\Thumbro\MediaTransformError`). Fully qualified.
- Dead `!isset( $library )` check after `$library = $option['library']`.
- Wrong `@param` name on `ThumbroBeforeProduceHtmlHook::onThumbroBeforeProduceHtml`.

### Imagick (optional PECL extension)
Phan didn't know about Imagick (it's not loaded in the CI/dev container), so every Imagick reference triggered `PhanUndeclaredClass*`. Rather than scattering suppressions, this PR adds a minimal stub at `.phan/stubs/imagick.phan_php` and wires it via `autoload_internal_extension_signatures` in `.phan/config.php`. Result: zero Imagick suppressions, and Phan type-checks the comparison code path properly (which is how the `getImageMetric` bug was found).

### Trait parent references
`ThumbroHandlerTrait` calls `parent::TRANSFORM_LATER`, `parent::doTransform()`, and `$this->normaliseParams()` — all provided by `TransformationalImageHandler`. Documented the constraint with `@require-extends \TransformationalImageHandler` (which makes Phan emit `PhanTraitRequireExtendsMissing` if a consumer doesn't extend it) and added three per-line `@phan-suppress-next-line` annotations because Phan 6.0.2 doesn't propagate `@require-extends` info into the trait body for type resolution.

### Lint-only fixes
- Wrap long lines in `ThumbroThumbnailImage.php` and `SpecialThumbroTest.php`.

## Test plan
- [x] `composer phpcs` passes (0 errors, 0 warnings)
- [x] `composer phan` passes (0 issues)
- [x] `composer preflight` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)