### PR TITLE
refactor: adopt PHP 8.1+ syntax and native types

### DIFF
--- a/includes/Hooks/HookRunner.php
+++ b/includes/Hooks/HookRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace MediaWiki\Extension\Thumbro\Hooks;
 
 use MediaWiki\Extension\Thumbro\ThumbroThumbnailImage;

--- a/includes/Hooks/MediaWikiHooks.php
+++ b/includes/Hooks/MediaWikiHooks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace MediaWiki\Extension\Thumbro\Hooks;
 
 use File;

--- a/includes/Hooks/ThumbroBeforeProduceHtmlHook.php
+++ b/includes/Hooks/ThumbroBeforeProduceHtmlHook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace MediaWiki\Extension\Thumbro\Hooks;
 
 use MediaWiki\Extension\Thumbro\ThumbroThumbnailImage;

--- a/includes/ShellCommand.php
+++ b/includes/ShellCommand.php
@@ -46,19 +46,11 @@ class ShellCommand {
 
 	protected bool $removeInput;
 
-	protected string $command;
-
-	protected array $args;
-
-	protected string $name;
-
-	/**
-	 * Constructor
-	 */
-	public function __construct( string $name, string $command, array $args ) {
-		$this->name = $name;
-		$this->command = $command;
-		$this->args = $args;
+	public function __construct(
+		private readonly string $name,
+		private readonly string $command,
+		private readonly array $args,
+	) {
 	}
 
 	/**
@@ -110,7 +102,7 @@ class ShellCommand {
 			if ( $value ) {
 				$cmdArg .= "=$value";
 			}
-			array_push( $cmdArgs, $cmdArg );
+			$cmdArgs[] = $cmdArg;
 		}
 		return $cmdArgs;
 	}

--- a/includes/SpecialThumbroTest.php
+++ b/includes/SpecialThumbroTest.php
@@ -20,6 +20,8 @@
  * @file
  */
 
+declare( strict_types=1 );
+
 namespace MediaWiki\Extension\Thumbro;
 
 use Imagick;
@@ -337,7 +339,7 @@ class SpecialThumbroTest extends SpecialPage {
 		$form = HTMLForm::factory( 'ooui', $this->getFormFields(), $this->getContext() );
 		$form->setWrapperLegend( $this->msg( 'thumbro-form-legend' )->text() );
 		$form->setSubmitText( $this->msg( 'thumbro-form-submit' )->text() );
-		$form->setSubmitCallback( [ __CLASS__, 'processForm' ] );
+		$form->setSubmitCallback( self::processForm( ... ) );
 		$form->setMethod( 'get' );
 
 		// Looks like HTMLForm does not actually show the form if submission
@@ -361,7 +363,7 @@ class SpecialThumbroTest extends SpecialPage {
 				'required'      => true,
 				'size' 			=> '80',
 				'label-message' => 'thumbro-form-file',
-				'validation-callback' => [ __CLASS__, 'validateFileInput' ],
+				'validation-callback' => self::validateFileInput( ... ),
 			],
 			'Width' => [
 				'name'          => 'width',
@@ -370,7 +372,7 @@ class SpecialThumbroTest extends SpecialPage {
 				'size'          => '5',
 				'required'      => true,
 				'label-message' => 'thumbro-form-width',
-				'validation-callback' => [ __CLASS__, 'validateWidth' ],
+				'validation-callback' => self::validateWidth( ... ),
 			],
 			/*
 			'SharpenRadius' => [
@@ -400,10 +402,7 @@ class SpecialThumbroTest extends SpecialPage {
 		return $fields;
 	}
 
-	/**
-	 * @return bool|string
-	 */
-	public static function validateFileInput( ?string $input, array $alldata ) {
+	public static function validateFileInput( ?string $input, array $alldata ): bool|string {
 		if ( $input === null || !trim( $input ) ) {
 			// Don't show an error if the file is not yet specified,
 			// because it is annoying
@@ -423,10 +422,7 @@ class SpecialThumbroTest extends SpecialPage {
 		return true;
 	}
 
-	/**
-	 * @return bool|string
-	 */
-	public static function validateWidth( int $input, array $allData ) {
+	public static function validateWidth( int $input, array $allData ): bool|string {
 		if (
 			$allData['File'] === null ||
 			self::validateFileInput( $allData['File'], $allData ) !== true ||
@@ -467,7 +463,7 @@ class SpecialThumbroTest extends SpecialPage {
 	/**
 	 * Stream thumbnail from Special:ThumbroTest&thumb=
 	 */
-	protected function streamThumbnail() {
+	protected function streamThumbnail(): void {
 		$request = $this->getRequest();
 
 		// Validate title and file existance


### PR DESCRIPTION
## Summary
A targeted modernization pass to bring the codebase in line with the AGENTS.md convention (\"use native PHP types throughout\") and pick up a handful of PHP 8.0/8.1 idioms.

### Changes
- **`declare(strict_types=1)`** added to the four PHP files that were missing it: `Hooks/HookRunner.php`, `Hooks/MediaWikiHooks.php`, `Hooks/ThumbroBeforeProduceHtmlHook.php`, `SpecialThumbroTest.php`.
- **`ShellCommand`** — collapse the manually-declared `name`/`command`/`args` properties into constructor property promotion with `readonly`. Also swap `array_push($a, $x)` for the idiomatic `$a[] = $x`.
- **`SpecialThumbroTest`** — promote `@return`-only PHPDoc to native return types (`: void` on `streamThumbnail`, `: bool|string` on `validateFileInput`/`validateWidth`). Convert the array-style callables (`[__CLASS__, 'method']`) used by `HTMLForm` into first-class callable syntax (`self::method(...)`).

Net diff: **-6 lines** (5 files, +20 / -26). No intentional behavior change.

## Test plan
- [x] `composer phpcs` — clean
- [x] `composer phan` — clean
- [x] `composer preflight` — green end-to-end
- [x] Smoke test on local MW Docker: PNG → WebP transform via libvips, `<picture>`/`<source srcset>` HTML renders, `Special:ThumbroTest` loads without 500
- [x] No errors in PHP/Apache logs during smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)