### PR TITLE
fix: avoid removed ParserEnableLegacyMediaDOM constant on MW 1.45+

### DIFF
--- a/includes/ThumbroThumbnailImage.php
+++ b/includes/ThumbroThumbnailImage.php
@@ -26,7 +26,11 @@ class ThumbroThumbnailImage extends ThumbnailImage {
 		$services = MediaWikiServices::getInstance();
 		$mainConfig = $services->getMainConfig();
 		$nativeImageLazyLoading = $mainConfig->get( MainConfigNames::NativeImageLazyLoading );
-		$enableLegacyMediaDOM = $mainConfig->get( MainConfigNames::ParserEnableLegacyMediaDOM );
+		// MainConfigNames::ParserEnableLegacyMediaDOM was removed in MW 1.45. Reference the config
+		// name as a string and guard with has() so 1.43/1.44 still honor the setting and 1.45+
+		// falls back to the (now hardcoded) non-legacy behavior.
+		$enableLegacyMediaDOM = $mainConfig->has( 'ParserEnableLegacyMediaDOM' )
+			&& $mainConfig->get( 'ParserEnableLegacyMediaDOM' );
 
 		if ( func_num_args() === 2 ) {
 			throw new InvalidArgumentException( __METHOD__ . ' called in the old style' );


### PR DESCRIPTION
## Summary
Fixes #38.

MediaWiki 1.45 removed `MainConfigNames::ParserEnableLegacyMediaDOM`, so referencing the constant from `ThumbroThumbnailImage::toHtml()` blew up with `Undefined constant MediaWiki\MainConfigNames::ParserEnableLegacyMediaDOM` on every thumbnail render under 1.45 — including special pages that gallery files (e.g. `Special:UnusedFiles` in the original report).

## Why this approach (not just dropping the legacy branch)
1.45 hardcodes the non-legacy DOM, but 1.43 and 1.44 still expose `\$wgParserEnableLegacyMediaDOM` and operators on those versions can still set it to `true`. Dropping the legacy branch entirely would silently change behavior for any 1.43/1.44 wiki that has legacy DOM enabled. So instead:

- Reference the config name as a string (`'ParserEnableLegacyMediaDOM'`) — that avoids the now-undefined class constant on 1.45.
- Guard with `Config::has()` so we only read the setting where it exists.
- Short-circuit to `false` on 1.45+, matching the now-hardcoded core behavior.

```php
\$enableLegacyMediaDOM = \$mainConfig->has( 'ParserEnableLegacyMediaDOM' )
    && \$mainConfig->get( 'ParserEnableLegacyMediaDOM' );
```

## Test plan
- [x] `composer preflight` passes (phpcs + phan + parallel-lint + minus-x)
- [x] Smoke test on local MW 1.43.6: PNG → WebP thumbnail still renders with picture/source/img and srcset
- [x] `Special:UnusedFiles` (the page from the bug report) returns 200, no `Undefined constant` in logs
- [ ] Cannot verify directly on 1.45 locally — verified by code inspection: `Config::has()` returns false there, fallback to `false`, no constant reference touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)