### PR TITLE
fix: serve original file for non-upscalable deferred transforms (#51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           files_yaml: |
             php:
               - includes/**/*.php
+              - tests/**/*.php
               - extension.json
               - composer.json
               - composer.lock
@@ -77,6 +78,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.php == 'true'
     uses: StarCitizenTools/mediawiki-ci-workflows/.github/workflows/analyze-php.yml@main
+    with:
+      project-type: extension
+      project-name: Thumbro
+      runner: ubuntu-24.04-arm
+
+  test-php:
+    needs: changes
+    if: needs.changes.outputs.php == 'true'
+    uses: StarCitizenTools/mediawiki-ci-workflows/.github/workflows/test-php.yml@main
     with:
       project-type: extension
       project-name: Thumbro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,14 +10,14 @@ Run only what's relevant to the files you changed.
 
 | Files changed | Command |
 | --- | --- |
-| `*.php` | `composer preflight` (lint, style, and Phan) |
+| `*.php` | `composer preflight` (lint, style, Phan, and PHPUnit) |
 | `*.js` | `npm run lint:js` |
 | `*.less`, `*.css` | `npm run lint:styles` |
 | `i18n/` | `npm run lint:i18n` |
 
 Auto-fix commands: `composer fix` (PHP), `npm run lint:fix:js` (JS), `npm run lint:fix:styles` (styles).
 
-**Preflight**: Run `npm run preflight` to execute all Node-based lints in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, and Phan static analysis.
+**Preflight**: Run `npm run preflight` to execute all Node-based lints in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, Phan static analysis, and PHPUnit tests.
 
 **Always run the relevant checks before committing.** Read the full output — PHPCS warnings must be fixed, not just errors. The command exits 0 even with warnings, so do not treat exit code alone as a pass.
 
@@ -32,6 +32,16 @@ docker compose exec mediawiki bash -c "cd /var/www/html/w/extensions/Thumbro && 
 ```
 
 Note: the `vipsthumbnail` binary (libvips) must be available in the environment for runtime thumbnail generation, but is not required for lint/test/Phan.
+
+### PHPUnit
+
+PHPUnit tests live under `tests/phpunit/` (auto-discovered via `TestAutoloadNamespaces` in `extension.json`) and require a full MediaWiki installation to run. From the MediaWiki core root:
+
+```sh
+docker compose exec mediawiki bash -c "cd /var/www/html/w && composer phpunit -- extensions/Thumbro/tests/phpunit"
+```
+
+Integration tests (those needing MediaWiki services, e.g. media-handler tests that exercise `normaliseParams`) go under `tests/phpunit/integration/`; pure unit tests go under `tests/phpunit/unit/`.
 
 ### Phan
 

--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,11 @@
 			"phpcs --config-set ignore_warnings_on_exit 1",
 			"phpcs -sp --cache"
 		],
+		"phpunit": "cd ../../ && composer phpunit -- extensions/Thumbro/tests/phpunit/",
 		"preflight": [
 			"@test",
-			"@phan"
+			"@phan",
+			"@phpunit"
 		]
 	},
 	"extra": {

--- a/extension.json
+++ b/extension.json
@@ -15,6 +15,9 @@
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\Thumbro\\": "includes/"
 	},
+	"TestAutoloadNamespaces": {
+		"MediaWiki\\Extension\\Thumbro\\Tests\\": "tests/phpunit/"
+	},
 	"SpecialPages": {
 		"ThumbroTest": "MediaWiki\\Extension\\Thumbro\\SpecialThumbroTest"
 	},

--- a/includes/MediaHandlers/ThumbroHandlerTrait.php
+++ b/includes/MediaHandlers/ThumbroHandlerTrait.php
@@ -44,6 +44,26 @@ trait ThumbroHandlerTrait {
 			return new TransformParameterError( $params );
 		}
 
+		// Mirror TransformationalImageHandler::doTransform()'s "return unscaled image" guard.
+		// normaliseParams() clamps physicalWidth/Height down to the source size when the
+		// requested size is larger (e.g. the responsive 1.5x/2x variants of an image that is
+		// smaller than the requested density). In that case core serves the original file
+		// rather than a thumbnail. Without this, the TRANSFORM_LATER path emits a thumb URL
+		// (e.g. 144px-Foo.webp) that thumb_handler.php rejects with HTTP 400 when
+		// $wgGenerateThumbnailOnParse = false. See issue #51.
+		if (
+			!$image->mustRender() &&
+			$params['physicalWidth'] == $image->getWidth() &&
+			$params['physicalHeight'] == $image->getHeight() &&
+			( $params['quality'] ?? null ) !== 'low'
+		) {
+			return $this->getClientScalingThumbnailImage( $image, [
+				'clientWidth' => $params['width'],
+				'clientHeight' => $params['height'],
+				'isFilePageThumb' => $params['isFilePageThumb'] ?? false,
+			] );
+		}
+
 		wfDebug( __METHOD__ . ": Transforming later per flags." );
 		$newParams = [
 			'width' => $params['width'],

--- a/tests/phpunit/integration/MediaHandlers/ThumbroHandlerTraitTest.php
+++ b/tests/phpunit/integration/MediaHandlers/ThumbroHandlerTraitTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Integration\MediaHandlers;
+
+use File;
+use MediaWiki\Extension\Thumbro\MediaHandlers\ThumbroWebPHandler;
+use MediaWiki\Extension\Thumbro\ThumbroThumbnailImage;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Thumbro\MediaHandlers\ThumbroHandlerTrait
+ * @group Thumbro
+ */
+class ThumbroHandlerTraitTest extends MediaWikiIntegrationTestCase {
+
+	private function makeFile( int $width, int $height, string $url ): File {
+		$file = $this->createMock( File::class );
+		$file->method( 'getWidth' )->willReturn( $width );
+		$file->method( 'getHeight' )->willReturn( $height );
+		$file->method( 'pageCount' )->willReturn( 1 );
+		$file->method( 'getMimeType' )->willReturn( 'image/webp' );
+		$file->method( 'mustRender' )->willReturn( false );
+		$file->method( 'getUrl' )->willReturn( $url );
+		return $file;
+	}
+
+	/**
+	 * When a deferred (TRANSFORM_LATER) transform requests a size at or above the source
+	 * dimensions — e.g. the responsive 1.5x/2x variants of an image smaller than the
+	 * requested density — the output must point at the original file, not a thumbnail URL
+	 * that thumb_handler.php would reject with HTTP 400 when $wgGenerateThumbnailOnParse is
+	 * false.
+	 *
+	 * Regression test for https://github.com/StarCitizenTools/mediawiki-extensions-Thumbro/issues/51
+	 *
+	 * @dataProvider provideUnscaledWidths
+	 */
+	public function testTransformLaterReturnsOriginalWhenNotUpscalable( int $requestedWidth ): void {
+		$originalUrl = '/w/images/f/f5/Anvil_Carrack.webp';
+		$thumbUrl = '/w/images/thumb/f/f5/Anvil_Carrack.webp/' . $requestedWidth . 'px-Anvil_Carrack.webp';
+		$file = $this->makeFile( 144, 144, $originalUrl );
+
+		$handler = new ThumbroWebPHandler();
+		$result = $handler->doTransform(
+			$file,
+			'/tmp/thumb.webp',
+			$thumbUrl,
+			[ 'width' => $requestedWidth ],
+			ThumbroWebPHandler::TRANSFORM_LATER
+		);
+
+		$this->assertInstanceOf( ThumbroThumbnailImage::class, $result );
+		$this->assertSame(
+			$originalUrl,
+			$result->getUrl(),
+			'A non-upscalable deferred transform must serve the original file URL'
+		);
+	}
+
+	public static function provideUnscaledWidths(): array {
+		return [
+			'exactly source size (1.5x of a 96px display)' => [ 144 ],
+			'larger than source (2x of a 96px display)' => [ 192 ],
+		];
+	}
+
+	/**
+	 * A genuine downscale (requested width below the source) must still defer to a
+	 * thumbnail URL.
+	 */
+	public function testTransformLaterReturnsThumbnailWhenDownscaling(): void {
+		$thumbUrl = '/w/images/thumb/f/f5/Anvil_Carrack.webp/96px-Anvil_Carrack.webp';
+		$file = $this->makeFile( 144, 144, '/w/images/f/f5/Anvil_Carrack.webp' );
+
+		$handler = new ThumbroWebPHandler();
+		$result = $handler->doTransform(
+			$file,
+			'/tmp/thumb.webp',
+			$thumbUrl,
+			[ 'width' => 96 ],
+			ThumbroWebPHandler::TRANSFORM_LATER
+		);
+
+		$this->assertInstanceOf( ThumbroThumbnailImage::class, $result );
+		$this->assertSame(
+			$thumbUrl,
+			$result->getUrl(),
+			'A downscaling deferred transform must point at the thumbnail URL'
+		);
+	}
+
+	/**
+	 * A forced low-quality re-render must still produce a thumbnail URL even when the
+	 * requested size matches the source, mirroring core's exclusion of the unscaled
+	 * shortcut when a quality override is set.
+	 */
+	public function testTransformLaterRendersAtSourceSizeForLowQuality(): void {
+		$thumbUrl = '/w/images/thumb/f/f5/Anvil_Carrack.webp/144px-Anvil_Carrack.webp';
+		$file = $this->makeFile( 144, 144, '/w/images/f/f5/Anvil_Carrack.webp' );
+
+		$handler = new ThumbroWebPHandler();
+		$result = $handler->doTransform(
+			$file,
+			'/tmp/thumb.webp',
+			$thumbUrl,
+			[ 'width' => 144, 'quality' => 'low' ],
+			ThumbroWebPHandler::TRANSFORM_LATER
+		);
+
+		$this->assertInstanceOf( ThumbroThumbnailImage::class, $result );
+		$this->assertSame(
+			$thumbUrl,
+			$result->getUrl(),
+			'A low-quality deferred transform must render rather than serve the original'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #51 — thumbnails broke under `$wgGenerateThumbnailOnParse = false` when an image was smaller than the requested responsive (1.5x/2x) density.

When `$wgGenerateThumbnailOnParse = false`, MediaWiki defers transforms with the `TRANSFORM_LATER` flag, routing into Thumbro's overridden `ThumbroHandlerTrait::doTransform()` instead of core's `TransformationalImageHandler::doTransform()`. Thumbro's branch ran `normaliseParams()` but then **unconditionally emitted a thumbnail URL**, omitting the "return unscaled image" guard core applies (core `TransformationalImageHandler::doTransform()` ~L163-172).

For a source image smaller than the requested density (e.g. the 1.5x/2x `srcset` variants of a 144px image), `normaliseParams()` clamps the physical dimensions down to the source size and core then serves the **original file**. Thumbro instead produced a thumb URL like `144px-Foo.webp`, which `thumb_handler.php` rejects with **HTTP 400** because it can't upscale. With the default `true`, the non-deferred path goes through core directly and works — which is why this only surfaced with on-demand thumbnailing.

## Fix

Mirror core's guard inside the `TRANSFORM_LATER` branch: when the clamped physical size equals the source size, `mustRender()` is false, and quality is not `low`, return `getClientScalingThumbnailImage()` (which points at the original file). Genuine downscales are unchanged.

## Tests & tooling

- New PHPUnit integration test covering the unscaled (1.5x/2x), downscaling, and forced-low-quality cases. Verified it's a true regression test: it **fails on the pre-fix code** and passes after.
- Wired PHPUnit into `composer.json` (`phpunit` script + preflight) and CI (`test-php` job + `tests/**/*.php` change filter), mirroring the TabberNeue setup.
- AGENTS.md docs for the new suite.

## Verification

- `composer phpunit` — 5 tests, 9 assertions, all green.
- `composer test` (parallel-lint, phpcs, minus-x) + `composer phan` — clean.
- **Smoke test** against the live MediaWiki stack with a real file (`Abstract_art.png`, 500×500, real `ThumbroPNGHandler`): requesting width 550 ≥ source 500 with `TRANSFORM_LATER` now returns the original URL instead of a thumb URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for image handler functionality, including tests for scaling behavior and quality rendering.

* **Documentation**
  * Updated development documentation to include testing instructions and test location guidance.

* **Chores**
  * Enhanced CI pipeline to automatically detect and run PHP tests on relevant changes.
  * Added test execution scripts to project build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->