### PR TITLE
docs: remove references to uncommitted spec from tracked files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ GD where it is a real core path) on the three axes Thumbro optimises: **file siz
 
 - Harness: `php tests/bench/benchmark.php` (see `tests/bench/README.md` for dev deps + setup).
 - Quality metric: **SSIMULACRA2** (bands: ≥90 visually lossless, ≥70 high, ≥50 medium).
-- Acceptance rule (full detail in `docs/superpowers/specs/2026-06-05-benchmark-harness-design.md` §6):
+- Acceptance rule (full detail in `tests/bench/README.md`):
   production-to-production **dominance** vs each applicable baseline — smaller at
   ≥ quality, or better at ≤ size — with hard safety constraints (quality ≥ 50,
   wall-time ≤ 3 s static / 10 s animated, peak RSS ≤ 512 MB) and soft budgets.

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -3,7 +3,7 @@
 Measures **file size**, **perceptual quality** (SSIMULACRA2), and **performance**
 (wall time + peak RSS) for Thumbro's handlers against the MediaWiki baselines
 (ImageMagick primary; GD where it is a real core path), and applies the acceptance
-gate from `docs/superpowers/specs/2026-06-05-benchmark-harness-design.md` (§6).
+gate described under **Acceptance gate** below.
 
 ## Dev dependencies (Debian 12 dev image)
 
@@ -41,14 +41,14 @@ Animation runs are slow (metric is per-frame ~0.6 s).
   (Exception: `tiny.png` is a perf/size-extreme fixture at near-zero downscale, where content doesn't affect the score.)
 - **Very small thumbnails (≤120px) give unstable, low SSIMULACRA2** regardless of real
   quality (the metric has too few scales). Treat ≤120px quality as advisory and
-  corroborate via the `--visual` contact sheet. See spec §5.2.
+  corroborate via the `--visual` contact sheet.
 
 ## Acceptance gate (summary)
 
 Production-to-production dominance vs each applicable baseline (smaller at ≥ quality, or
 better at ≤ size) → PASS; baseline dominates or a hard constraint breached (quality < 50,
 time > 3 s static / 10 s animated, RSS > 512 MB) → FAIL; a genuine trade-off →
-INCOMPARABLE (record a decision). Full detail: spec §6.
+INCOMPARABLE (record a decision in the PR).
 
 ## Add a fixture
 Edit `bin/make_corpus.php`, run it, add an entry to `corpus/manifest.json`.

--- a/tests/bench/src/GateThresholds.php
+++ b/tests/bench/src/GateThresholds.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\Thumbro\Bench;
 
-/** Named, overridable thresholds for the acceptance gate (spec §6.1). */
+/** Named, overridable thresholds for the acceptance gate (see tests/bench/README.md). */
 class GateThresholds {
 	public function __construct(
 		// Hard constraints (breach => FAIL)


### PR DESCRIPTION
## Summary

The merged benchmark-harness PR (#55) left tracked files pointing at `docs/superpowers/specs/2026-06-05-benchmark-harness-design.md` — a planning spec under `docs/superpowers/`, which is gitignored and intentionally never committed. Anyone cloning the repo follows those links to nothing.

This points them at the committed `tests/bench/README.md` (which already summarises the three-axis acceptance rule) and makes the README self-contained:
- `AGENTS.md` — "full detail in `tests/bench/README.md`"
- `tests/bench/README.md` — drops the spec-path link and the `spec §5.2` / `spec §6` shorthands; the gate summary it already contains is the reference
- `tests/bench/src/GateThresholds.php` — docblock now points at `tests/bench/README.md`

No behavior change. `composer test` clean.

## Test Plan
- [x] `git grep` for `docs/superpowers` / `spec §` / `benchmark-harness-design` in tracked non-docs files returns nothing
- [x] `composer test` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)