### PR TITLE
refactor: extract backend-selection seam; route Special:ThumbroTest through it

### DIFF
--- a/includes/BackendDispatcher.php
+++ b/includes/BackendDispatcher.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro;
+
+use File;
+use MediaTransformOutput;
+use MediaWiki\Config\Config;
+use MediaWiki\Extension\Thumbro\Libraries\Libvips;
+use MediaWiki\Extension\Thumbro\Libraries\Libwebp;
+use TransformationalImageHandler;
+
+/**
+ * Selects and invokes the thumbnail backend for an already-resolved option set
+ * (from Utils::getOptions).
+ *
+ * This is the single backend-selection seam, shared by the BitmapHandlerTransform
+ * hook and Special:ThumbroTest, so the backend a file is routed to can never diverge
+ * between production output and the sysop comparison page.
+ */
+class BackendDispatcher {
+
+	/**
+	 * Dispatch a transform to the backend named by the resolved options' 'library'.
+	 *
+	 * $options is the option set from Utils::getOptions() — it carries 'library',
+	 * 'command', 'inputOptions' and 'outputOptions'. Returns the backend's own return
+	 * value (false stops further processing).
+	 */
+	public static function dispatch(
+		TransformationalImageHandler $handler,
+		File $file,
+		array $params,
+		array $options,
+		Config $config,
+		?MediaTransformOutput &$mto
+	): bool {
+		$library = $options['library'] ?? 'libvips';
+
+		if ( $library === 'libwebp' ) {
+			return Libwebp::doTransform(
+				$handler, $file, $params, self::libwebpOptions( $config, $options ), $mto
+			);
+		}
+
+		return Libvips::doTransform( $handler, $file, $params, $options, $mto );
+	}
+
+	/**
+	 * Assemble the option bundle the Libwebp backend needs from the resolved $options
+	 * (Utils::getOptions) and config: the libvips command for the resize step and the
+	 * libvips delegation, the gif2webp command + flags for the encode step, the WebP-save
+	 * flags for the opaque/static libvips fallback, and the animated-area threshold.
+	 */
+	public static function libwebpOptions( Config $config, array $options ): array {
+		$libraries = $config->get( 'ThumbroLibraries' );
+		$gifOptions = $config->get( 'ThumbroOptions' )['image/gif'] ?? [];
+
+		return [
+			// libvips for the resize step and the libvips delegation.
+			'command' => $libraries['libvips']['command'] ?? $options['command'],
+			// gif2webp for the encode step.
+			'webpCommand' => $libraries['libwebp']['command'] ?? '',
+			'webpOptions' => $gifOptions['outputOptions'] ?? [],
+			// libvips WebP-save flags for the opaque/static delegation.
+			'outputOptions' => $options['outputOptions'] ?? [],
+			'inputOptions' => $options['inputOptions'] ?? [],
+			'maxAnimatedArea' => (int)$config->get( 'ThumbroMaxAnimatedArea' ),
+		];
+	}
+}

--- a/includes/Hooks/MediaWikiHooks.php
+++ b/includes/Hooks/MediaWikiHooks.php
@@ -8,8 +8,8 @@ use File;
 use MediaTransformOutput;
 use MediaWiki\Config\Config;
 use MediaWiki\Config\ConfigFactory;
+use MediaWiki\Extension\Thumbro\BackendDispatcher;
 use MediaWiki\Extension\Thumbro\Libraries\Libvips;
-use MediaWiki\Extension\Thumbro\Libraries\Libwebp;
 use MediaWiki\Extension\Thumbro\MediaHandlers;
 use MediaWiki\Extension\Thumbro\Utils;
 use MediaWiki\Hook\BitmapHandlerCheckImageAreaHook;
@@ -70,26 +70,7 @@ class MediaWikiHooks implements
 			return true;
 		}
 
-		$library = $options['library'] ?? 'libvips';
-
-		if ( $library === 'libwebp' ) {
-			$libraries = $config->get( 'ThumbroLibraries' );
-			$gifOptions = $config->get( 'ThumbroOptions' )['image/gif'] ?? [];
-			$webpOptions = [
-				// vips for the resize step and the libvips delegation.
-				'command' => $libraries['libvips']['command'] ?? $options['command'],
-				// gif2webp for the encode step.
-				'webpCommand' => $libraries['libwebp']['command'] ?? '',
-				'webpOptions' => $gifOptions['outputOptions'] ?? [],
-				// libvips WebP-save flags for the opaque/static delegation.
-				'outputOptions' => $options['outputOptions'] ?? [],
-				'inputOptions' => $options['inputOptions'] ?? [],
-				'maxAnimatedArea' => (int)$config->get( 'ThumbroMaxAnimatedArea' ),
-			];
-			return Libwebp::doTransform( $handler, $file, $params, $webpOptions, $mto );
-		}
-
-		return Libvips::doTransform( $handler, $file, $params, $options, $mto );
+		return BackendDispatcher::dispatch( $handler, $file, $params, $options, $config, $mto );
 	}
 
 	/**

--- a/includes/SpecialThumbroTest.php
+++ b/includes/SpecialThumbroTest.php
@@ -26,7 +26,6 @@ namespace MediaWiki\Extension\Thumbro;
 
 use Imagick;
 use MediaTransformOutput;
-use MediaWiki\Extension\Thumbro\Libraries\Libvips;
 use MediaWiki\Html\Html;
 use MediaWiki\HTMLForm\Field\HTMLIntField;
 use MediaWiki\HTMLForm\Field\HTMLTextField;
@@ -494,8 +493,6 @@ class SpecialThumbroTest extends SpecialPage {
 
 		$config = $this->getConfig();
 		$thumbroTestExpiry = $config->get( 'ThumbroTestExpiry' );
-		$thumbroOptions = $config->get( 'ThumbroOptions' );
-		$thumbroLibraries = $config->get( 'ThumbroLibraries' );
 
 		// Respect MediaHandler thumbType
 		[ $extension, $mimeType ] = $handler->getThumbType( $file->getExtension(), $inputMimeType );
@@ -530,29 +527,24 @@ class SpecialThumbroTest extends SpecialPage {
 			'interlace' => $request->getBool( 'interlace' ),
 		];
 
-		$library = $thumbroOptions[$mimeType]['library'] ?? 'libvips';
-		$options = [
-			'command' => $thumbroLibraries[$library]['command'],
-			'inputOptions' => $thumbroOptions[$inputMimeType]['inputOptions'] ?? [],
-			'outputOptions' => $thumbroOptions[$mimeType]['outputOptions'] ?? []
-		];
-
-		/*
-		if ( $request->getBool( 'bilinear' ) ) {
-			$options['bilinear'] = true;
-			wfDebug( __METHOD__ . ": using bilinear scaling" );
+		$options = Utils::getOptions( $handler, $file, $config );
+		if ( $options === null ) {
+			// getOptions() returns null for any file Thumbro will not transform: the output
+			// type's block is disabled, the file is multipage, or its area is outside the
+			// configured [minArea, maxArea) range.
+			$this->streamError(
+				500,
+				'Thumbro: this file is not handled (its type may be disabled, multipage, '
+					. 'or outside the configured size limits)'
+			);
+			return;
 		}
-		if ( $request->getRawVal( 'sharpen' ) !== null && $request->getFloat( 'sharpen' ) < 5 ) {
-			// Limit sharpen sigma to 5, otherwise we have to write huge convolution matrices
-			$sharpen = $request->getFloat( 'sharpen' );
-			$options['sharpen'] = [ 'sigma' => $sharpen ];
-			wfDebug( __METHOD__ . ": sharpening with radius {$sharpen}" );
-		}
-		*/
 
-		// Call the hook
+		// Dispatch through the same seam the BitmapHandlerTransform hook uses, so the
+		// comparison reflects the backend production actually serves (e.g. libwebp for
+		// animated GIFs) rather than always libvips.
 		/** @var MediaTransformOutput $mto */
-		Libvips::doTransform( $handler, $file, $scalerParams, $options, $mto );
+		BackendDispatcher::dispatch( $handler, $file, $scalerParams, $options, $config, $mto );
 		if ( $mto && !$mto->isError() ) {
 			wfDebug( __METHOD__ . ": streaming thumbnail..." );
 			$this->getOutput()->disable();

--- a/tests/phpunit/unit/BackendDispatcherTest.php
+++ b/tests/phpunit/unit/BackendDispatcherTest.php
@@ -1,0 +1,76 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Unit;
+
+use MediaWiki\Config\HashConfig;
+use MediaWiki\Extension\Thumbro\BackendDispatcher;
+use MediaWikiUnitTestCase;
+
+/**
+ * Unit tests for the pure option-bundle assembly extracted into the dispatch seam.
+ * (The dispatch() routing itself is exercised end to end by MediaWikiHooksTest.)
+ *
+ * @covers \MediaWiki\Extension\Thumbro\BackendDispatcher
+ */
+class BackendDispatcherTest extends MediaWikiUnitTestCase {
+
+	private function config(
+		array $libraries,
+		string|int $maxArea = 25000000,
+		array $gifOut = [ 'mixed' => '', 'q' => '80', 'm' => '4' ]
+	): HashConfig {
+		return new HashConfig( [
+			'ThumbroLibraries' => $libraries,
+			'ThumbroOptions' => [ 'image/gif' => [ 'outputOptions' => $gifOut ] ],
+			'ThumbroMaxAnimatedArea' => $maxArea,
+		] );
+	}
+
+	public function testAssemblesBundleFromConfigAndOptions(): void {
+		$config = $this->config( [
+			'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ],
+			'libwebp' => [ 'command' => '/usr/bin/gif2webp' ],
+		] );
+		$options = [
+			'library' => 'libwebp', 'command' => '/usr/bin/gif2webp',
+			'inputOptions' => [ 'n' => '-1' ], 'outputOptions' => [ 'Q' => '90' ],
+		];
+
+		$bundle = BackendDispatcher::libwebpOptions( $config, $options );
+
+		$this->assertSame( '/usr/bin/vipsthumbnail', $bundle['command'], 'resize/delegation uses libvips' );
+		$this->assertSame( '/usr/bin/gif2webp', $bundle['webpCommand'], 'encode uses gif2webp' );
+		$this->assertSame( [ 'mixed' => '', 'q' => '80', 'm' => '4' ], $bundle['webpOptions'] );
+		$this->assertSame( [ 'Q' => '90' ], $bundle['outputOptions'] );
+		$this->assertSame( [ 'n' => '-1' ], $bundle['inputOptions'] );
+		$this->assertSame( 25000000, $bundle['maxAnimatedArea'] );
+	}
+
+	public function testWebpCommandEmptyWhenLibwebpUnconfigured(): void {
+		// Without a gif2webp binary the bundle leaves webpCommand empty; the Libwebp
+		// backend then treats it as unavailable and delegates to libvips.
+		$config = $this->config( [ 'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ] ] );
+		$bundle = BackendDispatcher::libwebpOptions( $config, [ 'command' => '/usr/bin/vipsthumbnail' ] );
+
+		$this->assertSame( '', $bundle['webpCommand'] );
+		$this->assertSame( '/usr/bin/vipsthumbnail', $bundle['command'] );
+	}
+
+	public function testCommandFallsBackToResolvedOptionWhenLibvipsUnconfigured(): void {
+		$config = $this->config( [ 'libwebp' => [ 'command' => '/usr/bin/gif2webp' ] ] );
+		$bundle = BackendDispatcher::libwebpOptions( $config, [ 'command' => '/fallback/vipsthumbnail' ] );
+
+		$this->assertSame( '/fallback/vipsthumbnail', $bundle['command'] );
+	}
+
+	public function testMaxAnimatedAreaIsCastToInt(): void {
+		$config = $this->config(
+			[ 'libvips' => [ 'command' => '/v' ], 'libwebp' => [ 'command' => '/g' ] ],
+			'12345'
+		);
+		$bundle = BackendDispatcher::libwebpOptions( $config, [ 'command' => '/g' ] );
+
+		$this->assertSame( 12345, $bundle['maxAnimatedArea'] );
+	}
+}


### PR DESCRIPTION
## Summary

First targeted refactor under the characterization safety net (#59). It removes the one piece of real duplication in the backend layer: the `library`→backend dispatch lived inline in `onBitmapHandlerTransform` **and** was divergently reimplemented in `Special:ThumbroTest`. Extracting a single `BackendDispatcher` seam kills the duplication and fixes a long-standing comparison-page bug as a side effect.

Two commits, deliberately separated by risk:

### 1. `refactor:` extract the seam (behavior-preserving)
- New `includes/BackendDispatcher.php` with `dispatch()` (library → backend) and a pure `libwebpOptions()` (option-bundle assembly).
- `onBitmapHandlerTransform` delegates to it — its inline dispatch/bundle block is gone.
- **Behavior-preserving for the hook**: the characterization net (`MediaWikiHooksTest`, etc.) stays green and actually drives the moved code, including the size-based pin that fails if transparent GIFs regress to libvips. The newly-isolatable `libwebpOptions` gets unit tests (`BackendDispatcherTest`).

### 2. `fix:` route `Special:ThumbroTest` through the seam
- The page read `library` from the **output** mime (always `image/webp`) ⇒ always libvips ⇒ never showed the libwebp/gif2webp output production serves for animated GIFs. It now resolves via `Utils::getOptions()` and dispatches through the same seam.
- **Behavior change (now documented in the commit body):** files Thumbro won't transform (disabled block / multipage / area outside `[minArea, maxArea)`) now return a clear error instead of silently rendering a libvips thumbnail. The default config sets no min/maxArea, so in practice only disabled/multipage are affected.

## Review & verification

- **Code review:** ✅ Ready to merge. The extraction is a verbatim, fallback-for-fallback move; the test-page fix is correct. One review note (the test-page behavioral narrowing + a vague error message) was addressed — the error message now names the reasons and the commit body documents the change.
- **Automated:** `composer phpunit` — 73 green (net held ⇒ hook change behavior-preserving); `composer test` (lint) — clean.
- [x] **Manual smoke (the un-net-covered test-page path):** drove the page's exact new logic — `Utils::getOptions(MainConfig)` + `BackendDispatcher::dispatch` with the page's `scalerParams` — against a real uploaded transparent animated GIF on the dev wiki. Result: `library` resolves to **libwebp**, dispatch yields a `ThumbroThumbnailImage`, output is **3038 B (6 frames) vs the old libvips path's 13832 B** — i.e. the page now serves the libwebp output it previously never showed. ✅

## Why this and not the big refactor
The small, driver-motivated seam extraction discussed earlier — pays down concrete duplication and gives the eventual larger SOLID refactor a clean dispatch boundary to build on. Not a speculative abstraction: `BackendDispatcher` is static (matching `Utils`/`Libvips`/`Libwebp`), no interface/registry introduced for two backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved thumbnail processing backend routing for better consistency between test and production environments.

* **Bug Fixes**
  * Enhanced error handling in test thumbnail generation with clearer error messages.

* **Tests**
  * Added comprehensive unit tests for backend selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->