### PR TITLE
fix: locate vipsheader next to the configured vips binary

### DIFF
--- a/includes/Transparency.php
+++ b/includes/Transparency.php
@@ -14,14 +14,19 @@ class Transparency {
 	/**
 	 * @param string $srcPath Source file path.
 	 * @param string $vipsthumbnailCommand Configured vipsthumbnail binary path
-	 *   (vipsheader is derived from it — they ship together).
+	 *   (vipsheader is located next to it — they ship together).
 	 * @return bool True if the image reports an alpha band (>= 4 bands). On any
 	 *   failure (vipsheader missing / error) returns false — the safe default that
 	 *   keeps the file on libvips.
 	 */
 	public static function hasAlpha( string $srcPath, string $vipsthumbnailCommand ): bool {
-		$vipsheader = str_replace( 'vipsthumbnail', 'vipsheader', $vipsthumbnailCommand );
-		if ( $vipsheader === $vipsthumbnailCommand || !is_executable( $vipsheader ) ) {
+		// vipsheader ships alongside vipsthumbnail, so look for it in the same directory.
+		// This handles a renamed or wrapped vipsthumbnail (where substituting the binary
+		// name in the path would not), as long as vipsheader is its sibling.
+		$vipsheader = dirname( $vipsthumbnailCommand ) . '/vipsheader';
+		if ( !is_executable( $vipsheader ) ) {
+			wfDebug( "[Extension:Thumbro] vipsheader not found next to $vipsthumbnailCommand; "
+				. 'treating the image as opaque.' );
 			return false;
 		}
 		$result = Shell::command( [ $vipsheader, '-f', 'bands', $srcPath ] )->execute();

--- a/tests/phpunit/integration/TransparencyTest.php
+++ b/tests/phpunit/integration/TransparencyTest.php
@@ -70,10 +70,11 @@ class TransparencyTest extends MediaWikiIntegrationTestCase {
 		);
 	}
 
-	public function testNonVipsthumbnailCommandReturnsFalse(): void {
-		// The vipsheader path is derived by replacing 'vipsthumbnail' in the command;
-		// a command without that substring can't be derived => safe false.
-		$src = $this->makeGif( 'thumbro_tr2_', true );
-		$this->assertFalse( Transparency::hasAlpha( $src, '/usr/bin/convert' ) );
+	public function testVipsheaderMissingFromCommandDirReturnsFalse(): void {
+		// vipsheader is looked up as a sibling of the configured vips command; a command
+		// whose directory has no vipsheader can't be probed => safe false.
+		$this->assertFalse(
+			Transparency::hasAlpha( '/tmp/whatever.gif', '/nonexistent-thumbro-dir/vipsthumbnail' )
+		);
 	}
 }


### PR DESCRIPTION
## Summary

`Transparency::hasAlpha` (the alpha probe that routes only transparent animated GIFs to gif2webp) derived the `vipsheader` path by substituting `vipsthumbnail`→`vipsheader` in the configured command. That **silently failed** — returning false, so the image is treated as opaque and a transparent animated GIF misses the gif2webp optimization — whenever the configured command didn't contain the literal `vipsthumbnail` substring (a renamed or wrapped binary).

This looks for `vipsheader` as a **sibling of the configured binary** (`dirname($cmd) . '/vipsheader'`) instead, which handles a renamed/wrapped `vipsthumbnail`, and `wfDebug`s when it's missing so the fallback is diagnosable rather than invisible.

This was follow-up **#3** from the dispatch-seam refactor review.

## Note on the companion concern (#2 — the `ShellCommand` "400 KB" filesize limit)

Investigated and found to be a **non-issue, no change needed**. MediaWiki's `Shell\Command::limits(['filesize' => N])` treats `N` as **KB** (`Command.php` does `$limits['filesize'] * 1024`), so the hardcoded `409600` is **400 MB**, not 400 KB. No realistic thumbnail — animated or otherwise — approaches that ceiling, so there is no truncation risk to fix. (The earlier review note that flagged 400 KB misread the unit.)

## Test plan

- [x] `composer phpunit` — 73 green. The change is exercised in production context by `MediaWikiHooksTest::testTransparentAnimatedGifRoutesToLibwebp`, which drives the real hook → `hasAlpha('/usr/bin/vipsthumbnail')` → `/usr/bin/vipsheader` → gif2webp, with a size assertion that fails if the derivation breaks.
- [x] `TransparencyTest` updated: the substring-failure case is replaced by the new failure mode (no sibling `vipsheader` ⇒ safe false); transparent/opaque/missing-source paths still pinned via the real `vipsheader`.
- [x] `composer test` (lint) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)