### PR TITLE
refactor: per-MIME outputOptions; move gif2webp flags to the libwebp library

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,21 @@ wfLoadExtension( 'Thumbro' );
 > ℹ️ **Thumbro works out of the box — no configuration required.**
 
 ### `$wgThumbroLibraries`
-Lists the image libraries Thumbro can use and the command that runs each one.
+The image libraries Thumbro can use, and how to run each.
 
 Key | Description
 :--- | :---
-`command` | Path to the executable Thumbro runs for image transformation
+`command` | Path to the library's executable
+`flags` | Optional encoder flags for the library, passed straight through (libwebp → [`gif2webp`](https://developers.google.com/speed/webp/docs/gif2webp), e.g. `mixed`, `q`, `m`)
 
 Default:
 ```php
 $wgThumbroLibraries = [
 	'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ],
-	'libwebp' => [ 'command' => '/usr/bin/gif2webp' ],
+	'libwebp' => [
+		'command' => '/usr/bin/gif2webp',
+		'flags' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ]
+	],
 ];
 ```
 
@@ -55,8 +59,8 @@ Key | Description
 :--- | :---
 `enabled` | Turn Thumbro on or off for this file type
 `library` | Which library handles this type (a key from `$wgThumbroLibraries`)
-`inputOptions` | Options applied when loading and resizing the source image
-`outputOptions` | Options applied when saving the thumbnail. Valid keys depend on the chosen library — e.g. [`VipsForeignSave`](https://www.libvips.org/API/current/VipsForeignSave.html) options for `libvips`, or [`gif2webp`](https://developers.google.com/speed/webp/docs/gif2webp) flags (such as `mixed`, `q`, `m`) for `libwebp`
+`inputOptions` | Options for loading and resizing the source image
+`outputOptions` | WebP save options ([`VipsForeignSave`](https://www.libvips.org/API/current/VipsForeignSave.html)), e.g. `Q`, `strip`, `smart_subsample`. Set per file type; if omitted, the `image/webp` block's options apply. (gif2webp's encoder flags live on the `libwebp` library, not here.)
 
 Default:
 ```php
@@ -66,11 +70,6 @@ $wgThumbroOptions = [
 		'library' => 'libwebp',
 		'inputOptions' => [
 			'n' => '-1'
-		],
-		'outputOptions' => [
-			'mixed' => '',
-			'q' => '80',
-			'm' => '4'
 		]
 	],
 	'image/jpeg' => [

--- a/extension.json
+++ b/extension.json
@@ -99,7 +99,12 @@
 					"command": "/usr/bin/vipsthumbnail"
 				},
 				"libwebp": {
-					"command": "/usr/bin/gif2webp"
+					"command": "/usr/bin/gif2webp",
+					"flags": {
+						"mixed": "",
+						"q": "80",
+						"m": "4"
+					}
 				}
 			}
 		},
@@ -113,11 +118,6 @@
 					"library": "libwebp",
 					"inputOptions": {
 						"n": "-1"
-					},
-					"outputOptions": {
-						"mixed": "",
-						"q": "80",
-						"m": "4"
 					}
 				},
 				"image/jpeg": {

--- a/includes/Options/TransformOptionsResolver.php
+++ b/includes/Options/TransformOptionsResolver.php
@@ -10,11 +10,14 @@ use TransformationalImageHandler;
 /**
  * Resolves whether Thumbro should transform a file and, if so, with which options.
  *
- * Behaviour is ported verbatim from the former Utils::getOptions, including its quirk: every
- * Thumbro handler's getThumbType() reports image/webp, so the matched ThumbroOptions block is
- * always the image/webp one — only `library` and `inputOptions` are taken from the input-MIME
- * block, while `outputOptions` (and the enabled/minArea/maxArea gate) come from the webp block.
- * That quirk is preserved here; fixing it is a separate, non-behaviour-preserving change.
+ * Worth knowing: every Thumbro handler's getThumbType() reports image/webp, so the matched
+ * ThumbroOptions block is always image/webp — its enabled/minArea/maxArea gate the transform.
+ * `library`, `inputOptions` and `outputOptions` are each taken from the input-MIME block (falling
+ * back to the webp block), so a MIME can carry its own webpsave flags.
+ *
+ * A libwebp block is the exception for `outputOptions`: there they are gif2webp encoder flags
+ * (which live on the libwebp library), not webpsave flags, so libwebp always takes the webp-block
+ * fallback — the webpsave options its opaque-GIF -> libvips delegation needs.
  */
 class TransformOptionsResolver {
 
@@ -59,13 +62,20 @@ class TransformOptionsResolver {
 				continue;
 			}
 
+			// Per-MIME webpsave flags, falling back to the webp block. libwebp always takes the
+			// fallback (its outputOptions are encoder flags, not webpsave — see the class docblock);
+			// this also keeps old configs with gif2webp flags under image/gif.outputOptions safe.
+			$inputBlockOutput = $library === 'libwebp'
+				? null
+				: ( $options[$inputMimeType]['outputOptions'] ?? null );
+			$outputOptions = $inputBlockOutput ?? $option['outputOptions'] ?? [];
+
 			return new TransformOptions(
 				$library,
 				$libraries[$library]['command'],
-				// inputOptions come from the input-MIME block; outputOptions from the matched
-				// (webp) block — preserving the documented quirk.
+				// inputOptions come from the input-MIME block.
 				$options[$inputMimeType]['inputOptions'] ?? [],
-				$option['outputOptions'] ?? [],
+				$outputOptions,
 				!empty( $option['setcomment'] )
 			);
 		}

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -72,7 +72,9 @@ return [
 		$gifOptions = $config->get( 'ThumbroOptions' )['image/gif'] ?? [];
 		return new LibwebpSettings(
 			$libraries['libwebp']['command'] ?? '',
-			$gifOptions['outputOptions'] ?? [],
+			// gif2webp encoder flags live on the libwebp library; fall back to the pre-1.3.x
+			// location (image/gif.outputOptions) so existing configs keep working.
+			$libraries['libwebp']['flags'] ?? $gifOptions['outputOptions'] ?? [],
 			// libvips is the primary backend and is always configured; '' would only surface
 			// in a libwebp-without-libvips misconfiguration, which produces no thumbnail either way.
 			$libraries['libvips']['command'] ?? '',

--- a/tests/phpunit/integration/Backend/LibwebpSettingsWiringTest.php
+++ b/tests/phpunit/integration/Backend/LibwebpSettingsWiringTest.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Integration\Backend;
+
+use MediaWiki\Extension\Thumbro\Backend\LibwebpSettings;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * Verifies ServiceWiring sources the gif2webp encoder flags from ThumbroLibraries.libwebp.flags,
+ * falling back to the pre-1.3.x location (image/gif.outputOptions) so existing configs keep working.
+ *
+ * @coversNothing
+ * @group Thumbro
+ */
+class LibwebpSettingsWiringTest extends MediaWikiIntegrationTestCase {
+
+	private function settings(): LibwebpSettings {
+		return $this->getServiceContainer()->get( 'Thumbro.LibwebpSettings' );
+	}
+
+	public function testDefaultConfigSourcesFlagsFromLibwebpLibrary(): void {
+		// The shipped default puts the flags on the library and leaves the gif block without
+		// outputOptions, so a non-empty result proves the wiring reads the new location.
+		$this->assertSame( [ 'mixed' => '', 'q' => '80', 'm' => '4' ], $this->settings()->gif2webpFlags() );
+	}
+
+	public function testFlagsSourcedFromLibwebpLibraryWhenSet(): void {
+		$this->overrideConfigValue( 'ThumbroLibraries', [
+			'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ],
+			'libwebp' => [ 'command' => '/usr/bin/gif2webp', 'flags' => [ 'q' => '70', 'm' => '6' ] ],
+		] );
+		$this->assertSame( [ 'q' => '70', 'm' => '6' ], $this->settings()->gif2webpFlags() );
+	}
+
+	public function testLibraryFlagsWinOverStaleOldLocation(): void {
+		// Both set => the new library location wins; a stale image/gif.outputOptions is ignored.
+		$this->overrideConfigValue( 'ThumbroLibraries', [
+			'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ],
+			'libwebp' => [ 'command' => '/usr/bin/gif2webp', 'flags' => [ 'q' => '70' ] ],
+		] );
+		$this->overrideConfigValue( 'ThumbroOptions', [
+			'image/gif' => [ 'enabled' => true, 'library' => 'libwebp',
+				'inputOptions' => [ 'n' => '-1' ], 'outputOptions' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ] ],
+		] );
+		$this->assertSame( [ 'q' => '70' ], $this->settings()->gif2webpFlags() );
+	}
+
+	public function testFlagsFallBackToOldGifBlockLocation(): void {
+		// No flags on the library => fall back to the pre-1.3.x image/gif.outputOptions.
+		$this->overrideConfigValue( 'ThumbroLibraries', [
+			'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ],
+			'libwebp' => [ 'command' => '/usr/bin/gif2webp' ],
+		] );
+		$this->overrideConfigValue( 'ThumbroOptions', [
+			'image/gif' => [ 'enabled' => true, 'library' => 'libwebp',
+				'inputOptions' => [ 'n' => '-1' ], 'outputOptions' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ] ],
+		] );
+		$this->assertSame( [ 'mixed' => '', 'q' => '80', 'm' => '4' ], $this->settings()->gif2webpFlags() );
+	}
+}

--- a/tests/phpunit/unit/Options/TransformOptionsResolverTest.php
+++ b/tests/phpunit/unit/Options/TransformOptionsResolverTest.php
@@ -30,8 +30,9 @@ class TransformOptionsResolverTest extends MediaWikiUnitTestCase {
 				'libwebp' => [ 'command' => '/usr/bin/gif2webp' ],
 			],
 			'ThumbroOptions' => $optionsOverride ?: [
-				'image/gif' => [ 'enabled' => true, 'library' => 'libwebp',
-					'inputOptions' => [ 'n' => '-1' ], 'outputOptions' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ] ],
+				// gif2webp encoder flags now live on the libwebp library, not here; the gif block
+				// carries no outputOptions and its delegation webpsave falls back to the webp block.
+				'image/gif' => [ 'enabled' => true, 'library' => 'libwebp', 'inputOptions' => [ 'n' => '-1' ] ],
 				'image/jpeg' => [ 'enabled' => true, 'library' => 'libvips', 'inputOptions' => [] ],
 				'image/png' => [ 'enabled' => true, 'library' => 'libvips', 'inputOptions' => [] ],
 				'image/webp' => [ 'enabled' => true, 'library' => 'libvips',
@@ -139,5 +140,41 @@ class TransformOptionsResolverTest extends MediaWikiUnitTestCase {
 		$this->assertNotNull( $opts );
 		$this->assertSame( 'libvips', $opts->library() );
 		$this->assertSame( [], $opts->inputOptions() );
+	}
+
+	public function testLibvipsBlockUsesItsOwnOutputOptionsWhenSet(): void {
+		// The new capability: a libvips MIME block carries its own webpsave flags, taken in
+		// preference to the webp-block fallback.
+		$resolver = $this->resolver( [
+			'image/jpeg' => [ 'enabled' => true, 'library' => 'libvips',
+				'inputOptions' => [], 'outputOptions' => [ 'Q' => '82', 'strip' => 'true' ] ],
+			'image/webp' => [ 'enabled' => true, 'library' => 'libvips',
+				'inputOptions' => [],
+				'outputOptions' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ] ],
+		] );
+		$opts = $resolver->resolve( $this->handler(), $this->file( 'image/jpeg', 'jpg' ) );
+		$this->assertNotNull( $opts );
+		$this->assertSame( '82', $opts->outputOptions()['Q'], 'jpeg uses its own webpsave Q' );
+	}
+
+	public function testLibwebpBlockOutputOptionsAreNotLeakedAsWebpsave(): void {
+		// Back-compat guard: an old-style config still carries gif2webp flags under
+		// image/gif.outputOptions. Those must NOT surface as the resolved (webpsave) outputOptions;
+		// the libwebp delegation uses the webp block's webpsave flags instead.
+		$resolver = $this->resolver( [
+			'image/gif' => [ 'enabled' => true, 'library' => 'libwebp',
+				'inputOptions' => [ 'n' => '-1' ], 'outputOptions' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ] ],
+			'image/webp' => [ 'enabled' => true, 'library' => 'libvips',
+				'inputOptions' => [],
+				'outputOptions' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ] ],
+		] );
+		$opts = $resolver->resolve( $this->handler(), $this->file( 'image/gif', 'gif' ) );
+		$this->assertNotNull( $opts );
+		$this->assertSame(
+			[ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ],
+			$opts->outputOptions(),
+			'libwebp delegation uses webp-block webpsave flags, not the gif2webp flags'
+		);
+		$this->assertArrayNotHasKey( 'mixed', $opts->outputOptions() );
 	}
 }


### PR DESCRIPTION
## Summary

Behaviour-preserving config-model cleanup that unblocks per-MIME webpsave tuning.

The `outputOptions` config key was **overloaded**: for `image/gif` it held gif2webp *encoder* flags (`{mixed, q, m}`); for jpeg/png/webp it would mean vipsthumbnail *webpsave* flags. And `TransformOptionsResolver` always read `outputOptions` from the matched block — which is always `image/webp` — so per-MIME webpsave options were dead.

This change:
1. **Moves the gif2webp flags to the libwebp library** (`ThumbroLibraries.libwebp.flags`); removes `image/gif.outputOptions`. `outputOptions` now uniformly means vipsthumbnail webpsave flags.
2. **Resolves `outputOptions` per input-MIME** (fallback to the webp block), like `library`/`inputOptions` already are. A `libwebp`-routed block uses the webp-block fallback for its opaque-GIF→libvips delegation webpsave (its own `outputOptions` are not webpsave flags) — which also keeps **pre-1.3.x configs** (gif2webp flags still under `image/gif.outputOptions`) working.
3. **ServiceWiring** sources gif2webp flags from `libwebp.flags`, falling back to the old location (back-compat).

**Behaviour-preserving:** with the default config every MIME still resolves to the webp block's `{strip, Q=90, smart_subsample}` via fallback. This **enables, but does not yet use**, per-MIME tuning.

## Review & verification

- **Code review:** ✅ Ready to merge — reviewer traced all five MIME paths and both old/new config shapes and confirmed behaviour-preservation + back-compat; no Critical/Important findings. The three Minor nits were applied (added a "both-set precedence" wiring test, renamed a local, tightened a docblock).
- **Automated:** `composer phpunit` — **108 green** (the characterization net held = behaviour-preserving proof; new resolver + wiring tests, incl. the back-compat fallback). `composer test` (lint) — clean.
- **Smoke (before/after byte comparison):** drove the **real** `BitmapHandlerTransform` hook (resolver → ServiceWiring → backend → binary) on this branch and on `main`, for jpeg/png/transparent-gif/opaque-gif. Output is **sha256-identical** across the config-shape change:

  | MIME | sha (main = branch) | size |
  | --- | --- | --- |
  | jpeg | `5a443bf418ef2a6a` | 1862 B |
  | png | `7cdd436e322ba9a6` | 856 B |
  | transparent gif | `c91076221ba3449c` | 1622 B (gif2webp) |
  | opaque gif | `cb9157ee87d57e83` | 4400 B (libvips delegation) |

## Follow-up (not in this PR)

**Harness-driven per-MIME tuning** — now that per-MIME `outputOptions` are enabled, run `tests/bench/benchmark.php` per MIME and set tuned webpsave options only where a variant dominates the IM/GD baselines (separate PR, with harness evidence; may find no headroom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)