### PR TITLE
test: make the benchmark report easier to read

### DIFF
--- a/tests/bench/src/Orchestrator.php
+++ b/tests/bench/src/Orchestrator.php
@@ -51,9 +51,13 @@ class Orchestrator {
 		$applicableBaselines = array_values( array_filter(
 			$this->baselines, static fn ( Contender $c ) => $c->applies( $mime ) && $c->isAvailable()
 		) );
+		// Score each baseline's quality once (the gate needs it, and the reporter shows it).
 		$baseResults = [];
+		$baseQualities = [];
 		foreach ( $applicableBaselines as $b ) {
-			$baseResults[$b->name()] = $b->run( $entry['path'], $mime, $w, $dir );
+			$res = $b->run( $entry['path'], $mime, $w, $dir );
+			$baseResults[$b->name()] = $res;
+			$baseQualities[$b->name()] = $res->available ? $this->scoreQuality( $res, $entry, $dir ) : null;
 		}
 
 		$candResults = [];
@@ -67,13 +71,12 @@ class Orchestrator {
 			if ( $res->available && $quality !== null ) {
 				$gate = new AcceptanceGate( new GateThresholds(), $entry['animated'] );
 				foreach ( $baseResults as $name => $base ) {
-					if ( !$base->available ) {
+					if ( !$base->available || $baseQualities[$name] === null ) {
 						continue;
 					}
-					$baseQ = $this->scoreQuality( $base, $entry, $dir );
 					$verdicts[$name] = $gate->evaluate(
 						$res->bytes ?? 0, $quality->mean, $res->wallMs ?? 0.0, $res->peakRssKb ?? 0,
-						$base->bytes ?? 0, $baseQ->mean, $base->wallMs ?? 0.0, $base->peakRssKb ?? 0
+						$base->bytes ?? 0, $baseQualities[$name]->mean, $base->wallMs ?? 0.0, $base->peakRssKb ?? 0
 					);
 				}
 			}
@@ -83,7 +86,8 @@ class Orchestrator {
 		return [
 			'source' => $entry['path'], 'mime' => $mime, 'width' => $w,
 			'animated' => $entry['animated'], 'frames' => $entry['frames'],
-			'baselines' => $baseResults, 'candidates' => $candResults, 'dir' => $dir,
+			'baselines' => $baseResults, 'baselineQualities' => $baseQualities,
+			'candidates' => $candResults, 'dir' => $dir,
 		];
 	}
 

--- a/tests/bench/src/Reporter.php
+++ b/tests/bench/src/Reporter.php
@@ -11,33 +11,131 @@ class Reporter {
 		return $path;
 	}
 
+	/** Plain-language labels for the gate's soft-budget flags. */
+	private const FLAG_LABELS = [
+		'memory-regression' => 'more memory',
+		'time-regression' => 'slower',
+	];
+
 	/** @param array<int,array<string,mixed>> $rows */
 	public function printTable( array $rows ): void {
+		// summary[baseline] = [ win, trade, loss ]
+		$summary = [];
 		foreach ( $rows as $row ) {
-			printf( "\n%s  @%dpx  (%s%s)\n", basename( $row['source'] ), $row['width'],
-				$row['mime'], $row['animated'] ? ", {$row['frames']}f animated" : '' );
-			foreach ( $row['baselines'] as $name => $r ) {
-				printf( "  baseline %-4s  %s\n", $name, $this->fmt( $r, null ) );
-			}
-			foreach ( $row['candidates'] as $name => $c ) {
-				printf( "  %-13s %s\n", $name, $this->fmt( $c['result'], $c['quality'] ) );
-				foreach ( $c['verdicts'] as $base => $v ) {
-					$extra = $v->reasons ? ' reasons=' . implode( ',', $v->reasons ) : '';
-					$extra .= $v->flags ? ' flags=' . implode( ',', $v->flags ) : '';
-					printf( "      vs %-4s: %s%s\n", $base, $v->verdict->value, $extra );
-				}
+			$this->printRow( $row, $summary );
+		}
+		$this->printSummary( $summary );
+	}
+
+	/**
+	 * @param array<string,mixed> $row
+	 * @param array<string,array<string,int>> &$summary
+	 */
+	private function printRow( array $row, array &$summary ): void {
+		printf( "\n%s · %dpx · %s%s\n",
+			basename( $row['source'] ), $row['width'], $row['mime'],
+			$row['animated'] ? " · {$row['frames']}f animated" : '' );
+		printf( "  %-15s %9s  %-24s %8s  %7s\n", 'contender', 'size', 'SSIM2', 'time', 'peak RSS' );
+
+		foreach ( $row['baselines'] as $name => $r ) {
+			$label = strtoupper( $name ) . ' (baseline)';
+			$this->printContenderRow( $label, $r, $row['baselineQualities'][$name] ?? null );
+		}
+		foreach ( $row['candidates'] as $name => $c ) {
+			$this->printContenderRow( $name, $c['result'], $c['quality'] );
+			foreach ( $c['verdicts'] as $base => $v ) {
+				printf( "    vs %-3s  %s\n", strtoupper( $base ),
+					$this->verdictLine( $v, $c['result'], $row['baselines'][$base], $c['quality'] ) );
+				$bucket = match ( $v->verdict ) {
+					Verdict::PASS => 'win',
+					Verdict::FAIL => 'loss',
+					Verdict::INCOMPARABLE => 'trade',
+				};
+				$summary[$base][$bucket] = ( $summary[$base][$bucket] ?? 0 ) + 1;
 			}
 		}
 	}
 
-	private function fmt( Result $r, ?Quality $q ): string {
+	private function printContenderRow( string $label, Result $r, ?Quality $q ): void {
 		if ( !$r->available ) {
-			return 'UNAVAILABLE (' . $r->error . ')';
+			printf( "  %-15s  UNAVAILABLE (%s)\n", $label, trim( $r->error ) );
+			return;
 		}
-		$s = sprintf( '%8d B  %6.0f ms  %7d KB', $r->bytes, $r->wallMs, $r->peakRssKb );
-		if ( $q !== null ) {
-			$s .= sprintf( '  SSIM2 %5.1f (%s)', $q->mean, $q->band() );
+		$ssim = $q !== null ? sprintf( '%5.1f %s', $q->mean, $q->band() ) : '-';
+		printf( "  %-15s %7d B  %-24s %5.0f ms  %4d MB\n",
+			$label, $r->bytes, $ssim, $r->wallMs, (int)round( $r->peakRssKb / 1024 ) );
+	}
+
+	/** A symbol + plain-language verdict for one candidate-vs-baseline comparison. */
+	private function verdictLine( GateResult $g, Result $cand, Result $base, Quality $candQ ): string {
+		[ $symbol, $word ] = match ( $g->verdict ) {
+			Verdict::PASS => [ '✓', 'WIN' ],
+			Verdict::FAIL => [ '✗', 'LOSS' ],
+			Verdict::INCOMPARABLE => [ '~', 'TRADE-OFF' ],
+		};
+		return sprintf( '%s %-9s — %s', $symbol, $word, $this->detail( $g, $cand, $base, $candQ ) );
+	}
+
+	private function detail( GateResult $g, Result $cand, Result $base, Quality $candQ ): string {
+		// Hard-constraint failures explain themselves; report the breach.
+		if ( in_array( 'quality-floor', $g->reasons, true ) ) {
+			return sprintf( 'quality %.1f is below the minimum floor', $candQ->mean );
 		}
-		return $s;
+		if ( in_array( 'time-ceiling', $g->reasons, true ) ) {
+			return 'over the hard time ceiling';
+		}
+		if ( in_array( 'rss-ceiling', $g->reasons, true ) ) {
+			return 'over the hard memory ceiling';
+		}
+
+		$size = $this->sizeDelta( $cand->bytes, $base->bytes );
+		if ( in_array( 'baseline-dominates', $g->reasons, true ) ) {
+			return "$size; the baseline dominates (no worse on size and quality)";
+		}
+
+		// PASS / INCOMPARABLE: size, then the quality relation, then any soft trade-offs.
+		$quality = in_array( 'quality-below-baseline', $g->flags, true )
+			? 'lower quality'
+			: 'comparable or better quality';
+		$detail = "$size at $quality";
+		$soft = [];
+		foreach ( $g->flags as $f ) {
+			if ( isset( self::FLAG_LABELS[$f] ) ) {
+				$soft[] = self::FLAG_LABELS[$f];
+			}
+		}
+		if ( $soft !== [] ) {
+			$detail .= ', but ' . implode( ' and ', $soft );
+		}
+		return $detail;
+	}
+
+	private function sizeDelta( int $cand, int $base ): string {
+		if ( $base <= 0 ) {
+			return $cand . ' B';
+		}
+		$pct = (int)round( ( $cand - $base ) / $base * 100 );
+		if ( $pct < 0 ) {
+			return abs( $pct ) . '% smaller';
+		}
+		if ( $pct > 0 ) {
+			return $pct . '% larger';
+		}
+		return 'same size';
+	}
+
+	/** @param array<string,array<string,int>> $summary */
+	private function printSummary( array $summary ): void {
+		if ( $summary === [] ) {
+			return;
+		}
+		print "\n";
+		foreach ( $summary as $base => $b ) {
+			$win = $b['win'] ?? 0;
+			$trade = $b['trade'] ?? 0;
+			$loss = $b['loss'] ?? 0;
+			printf( "Summary vs %s: %d win · %d trade-off · %d loss  (%d cases)\n",
+				strtoupper( $base ), $win, $trade, $loss, $win + $trade + $loss );
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Dev-tooling only — no production/extension code. Makes `php tests/bench/benchmark.php`'s printed table readable.

**Before**
```
alpha.png  320px  (image/png)
  baseline im        4843 B      28 ms    12836 KB
  baseline gd        8579 B      63 ms    38760 KB
  thumbro-vips      5754 B      92 ms    45296 KB  SSIM2  94.6 (visually lossless)
      vs im  : FAIL reasons=baseline-dominates flags=memory-regression
      vs gd  : PASS
```

**After**
```
alpha.png · 320px · image/png
  contender            size  SSIM2                        time  peak RSS
  IM (baseline)      4843 B   97.6 visually lossless      28 ms    13 MB
  GD (baseline)      8579 B   85.3 high                   63 ms    38 MB
  thumbro-vips       5754 B   94.6 visually lossless      92 ms    44 MB
    vs IM   ✗ LOSS      — 19% larger; the baseline dominates (no worse on size and quality)
    vs GD   ✓ WIN       — 33% smaller at comparable or better quality

Summary vs IM: 0 win · 0 trade-off · 1 loss  (1 cases)
Summary vs GD: 1 win · 0 trade-off · 0 loss  (1 cases)
```

## Changes
- **Header row + aligned columns**; humanized peak RSS (MB).
- **Baseline SSIM2 is now shown** — previously the gate computed it but the table never printed it, so `quality-below-baseline` had nothing to compare against.
- **Plain-language verdicts**: a symbol + word + the size delta and the trade-off reason (`memory-regression` → "more memory", `quality-floor` → "below the minimum quality floor", etc.). `✓ WIN` / `✗ LOSS` / `~ TRADE-OFF` map to PASS / FAIL / INCOMPARABLE.
- **Win/trade-off/loss summary** per baseline at the end.
- `Orchestrator` now scores each baseline's quality **once** (it was being recomputed per candidate — SSIMULACRA2 is ~0.6 s/frame) and carries it on the row.

The structured `results.json` is unchanged, so the raw flag/reason tokens are still available for tooling/grep.

## Verification
- `composer test` (lint) — clean. 21 bench unit tests green. Gate verdicts unchanged (the Orchestrator refactor feeds the same baseline quality to `AcceptanceGate::evaluate`).
- Reviewed; the two follow-ups it surfaced (SSIM2 column width for the longest band; `baseline-dominates` wording) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Benchmark test execution now caches baseline quality scores for improved performance.

* **Improvements**
  * Benchmark reports now display aggregated win/trade/loss outcome summaries for easier assessment.
  * Verdict comparisons include detailed constraint analysis with hard-constraint reasons and soft trade-off reasoning.
  * Enhanced metrics formatting and structured per-run data for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
