### PR TITLE
test(bench): faithful GIF contender + fix animated-WebP frame scoring

### DIFF
--- a/tests/bench/src/Contenders/ThumbroGif.php
+++ b/tests/bench/src/Contenders/ThumbroGif.php
@@ -1,0 +1,211 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Bench\Contenders;
+
+use MediaWiki\Extension\Thumbro\Bench\Contender;
+use MediaWiki\Extension\Thumbro\Bench\ImageDims;
+use MediaWiki\Extension\Thumbro\Bench\Result;
+use MediaWiki\Extension\Thumbro\Bench\Subprocess;
+use MediaWiki\Extension\Thumbro\Bench\ToolLocator;
+
+/**
+ * Reproduces Thumbro's GIF path faithfully — the part the libvips-only contender could not.
+ *
+ * Production routes GIFs through LibwebpBackend, which makes a runtime decision (see
+ * {@see self::chooseStrategy()}, mirrored from LibwebpBackend::chooseStrategy and locked by a
+ * truth-table test): transparent animated GIFs under the area threshold are encoded with
+ * gif2webp (the two-step vipsthumbnail -> temp .gif -> gif2webp pipeline); opaque or
+ * over-threshold animations delegate to libvips as animated WebP (n=-1); static GIFs take the
+ * first frame (n=1). The routing inputs — animation, frame count, transparency, area — are
+ * probed at runtime with vipsheader, exactly as production does (its AlphaDetector reads
+ * `vipsheader -f bands`), so the contender never goes stale against a hand-kept manifest.
+ *
+ * Encoder settings come from extension.json: the webpsave options (image/webp block) for the
+ * libvips delegation, and the gif2webp flags (ThumbroLibraries.libwebp.flags) for the encoder.
+ */
+class ThumbroGif implements Contender {
+
+	public function name(): string {
+		return 'thumbro-gif';
+	}
+
+	public function applies( string $mime ): bool {
+		return $mime === 'image/gif';
+	}
+
+	public function isAvailable(): bool {
+		// vipsthumbnail drives every strategy (gif2webp is optional: without it, transparent
+		// animations fall back to the libvips delegation, matching production).
+		return ToolLocator::path( 'vipsthumbnail' ) !== null;
+	}
+
+	/**
+	 * The runtime routing decision, copied verbatim from LibwebpBackend::chooseStrategy. A unit
+	 * test asserts the two stay identical across the whole truth table (the standalone harness
+	 * can't load the production class, so the rule is mirrored, not shared).
+	 *
+	 * @return string 'libwebp' | 'vips-animated' | 'vips-static'
+	 */
+	public static function chooseStrategy(
+		bool $animated, bool $underThreshold, bool $hasTransparency, bool $libwebpAvailable
+	): string {
+		if ( !$animated || !$underThreshold ) {
+			return 'vips-static';
+		}
+		if ( $hasTransparency && $libwebpAvailable ) {
+			return 'libwebp';
+		}
+		return 'vips-animated';
+	}
+
+	public function run( string $srcPath, string $mime, int $targetWidth, string $destDir ): Result {
+		$vips = ToolLocator::path( 'vipsthumbnail' );
+		if ( $vips === null ) {
+			return Result::unavailable( $this->name(), $srcPath, $targetWidth, 'vipsthumbnail not found' );
+		}
+		$cfg = self::config();
+
+		// Probe the routing inputs the way production does (frame count + transparency from the
+		// header; area = width * height * frames, like core GIFHandler::getImageArea).
+		$frames = max( 1, self::probe( $srcPath, 'n-pages' ) ?? 1 );
+		$animated = $frames > 1;
+		[ $w, $h ] = ImageDims::of( $srcPath );
+		$underThreshold = ( $w * $h * $frames ) <= $cfg['maxAnimatedArea'];
+		$gif2webp = ToolLocator::path( 'gif2webp' );
+		$libwebpAvailable = $gif2webp !== null;
+		// Only probe transparency when it can change the decision (matches production).
+		$hasTransparency = $animated && $underThreshold && $libwebpAvailable
+			&& ( self::probe( $srcPath, 'bands' ) ?? 0 ) >= 4;
+
+		$strategy = self::chooseStrategy( $animated, $underThreshold, $hasTransparency, $libwebpAvailable );
+		$dst = $destDir . '/thumbro_' . $targetWidth . '.webp';
+
+		if ( $strategy === 'libwebp' ) {
+			return $this->runLibwebp( $vips, (string)$gif2webp, $srcPath, $targetWidth, $dst, $cfg );
+		}
+		return $this->runVips( $vips, $strategy, $srcPath, $targetWidth, $dst, $cfg );
+	}
+
+	/** vips-static (first frame, n=1) or vips-animated (all frames, n=-1) -> WebP with webpsave opts. */
+	private function runVips(
+		string $vips, string $strategy, string $srcPath, int $targetWidth, string $dst, array $cfg
+	): Result {
+		$n = $strategy === 'vips-static' ? '1' : '-1';
+		$out = $dst . self::makeOptions( $cfg['webpOutput'] );
+		$cmd = [ $vips, $srcPath . "[n=$n]", '--size', $targetWidth . 'x100000', '-o', $out ];
+
+		$proc = Subprocess::run( $cmd );
+		if ( !$proc->ok() || !is_file( $dst ) ) {
+			return Result::unavailable( $this->name(), $srcPath, $targetWidth, 'vips failed: ' . $proc->stderr );
+		}
+		return new Result(
+			$this->name(), $srcPath, $targetWidth, $dst,
+			filesize( $dst ), $proc->wallMs, $proc->peakRssKb, true
+		);
+	}
+
+	/**
+	 * The two-step gif2webp pipeline: resize to a temp animated GIF, then encode to animated
+	 * WebP with gif2webp. Wall time is the sum of both steps; peak RSS the max (they run in
+	 * sequence). Mirrors LibwebpBackend::planLibwebpEncode.
+	 */
+	private function runLibwebp(
+		string $vips, string $gif2webp, string $srcPath, int $targetWidth, string $dst, array $cfg
+	): Result {
+		$tmpGif = dirname( $dst ) . '/thumbro_resize_' . $targetWidth . '.gif';
+		// Load options are the configured gif block's (production's planLibwebpEncode uses
+		// inputOptions() verbatim here, unlike the delegation paths which force n at runtime).
+		$resize = [ $vips, $srcPath . self::makeOptions( $cfg['gifInput'] ), '--size', $targetWidth . 'x100000', '-o', $tmpGif ];
+		$p1 = Subprocess::run( $resize );
+		if ( !$p1->ok() || !is_file( $tmpGif ) ) {
+			return Result::unavailable( $this->name(), $srcPath, $targetWidth, 'vips resize failed: ' . $p1->stderr );
+		}
+
+		$encode = array_merge( [ $gif2webp ], self::gif2webpArgs( $cfg['gif2webpFlags'] ), [ $tmpGif, '-o', $dst ] );
+		$p2 = Subprocess::run( $encode );
+		// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		@unlink( $tmpGif );
+		if ( !$p2->ok() || !is_file( $dst ) ) {
+			return Result::unavailable( $this->name(), $srcPath, $targetWidth, 'gif2webp failed: ' . $p2->stderr );
+		}
+		return new Result(
+			$this->name(), $srcPath, $targetWidth, $dst, filesize( $dst ),
+			$p1->wallMs + $p2->wallMs, max( $p1->peakRssKb ?? 0, $p2->peakRssKb ?? 0 ), true
+		);
+	}
+
+	/**
+	 * Render gif2webp flags as argv tokens, matching ShellCommand's 'gif2webp' style: each flag
+	 * is "-key", with a following value token only when the flag carries one ("" means bare).
+	 *
+	 * @param array<string,string> $flags
+	 * @return string[]
+	 */
+	private static function gif2webpArgs( array $flags ): array {
+		$args = [];
+		foreach ( $flags as $key => $value ) {
+			$args[] = "-$key";
+			if ( $value !== '' && $value !== null && $value !== true ) {
+				$args[] = (string)$value;
+			}
+		}
+		return $args;
+	}
+
+	/**
+	 * Format an options array as a "[key=value,...]" suffix, empty array -> "". Matches
+	 * LibvipsBackend::makeOptions.
+	 *
+	 * @param array<string,mixed> $args
+	 */
+	private static function makeOptions( array $args ): string {
+		if ( $args === [] ) {
+			return '';
+		}
+		$parts = [];
+		foreach ( $args as $key => $value ) {
+			$parts[] = "$key=$value";
+		}
+		return '[' . implode( ',', $parts ) . ']';
+	}
+
+	/** A single integer header field via vipsheader, or null if unavailable. */
+	private static function probe( string $path, string $field ): ?int {
+		$vipsheader = ToolLocator::path( 'vipsheader' );
+		if ( $vipsheader === null ) {
+			return null;
+		}
+		$proc = Subprocess::run( [ $vipsheader, '-f', $field, $path ] );
+		if ( !$proc->ok() ) {
+			return null;
+		}
+		$value = trim( $proc->stdout );
+		return $value === '' ? null : (int)$value;
+	}
+
+	/**
+	 * Encoder settings from extension.json: webpsave options for the libvips delegation, gif2webp
+	 * flags for the encoder, and the animated-area threshold.
+	 *
+	 * @return array{webpOutput:array<string,string>,gifInput:array<string,string>,gif2webpFlags:array<string,string>,maxAnimatedArea:int}
+	 */
+	private static function config(): array {
+		static $cache = null;
+		if ( $cache === null ) {
+			$json = json_decode(
+				(string)file_get_contents( __DIR__ . '/../../../../extension.json' ), true
+			);
+			$config = $json['config'] ?? [];
+			$opts = $config['ThumbroOptions']['value'] ?? [];
+			$libs = $config['ThumbroLibraries']['value'] ?? [];
+			$cache = [
+				'webpOutput' => $opts['image/webp']['outputOptions'] ?? [],
+				'gifInput' => $opts['image/gif']['inputOptions'] ?? [],
+				'gif2webpFlags' => $libs['libwebp']['flags'] ?? [],
+				'maxAnimatedArea' => (int)( $config['ThumbroMaxAnimatedArea']['value'] ?? 0 ),
+			];
+		}
+		return $cache;
+	}
+}

--- a/tests/bench/src/Contenders/ThumbroVips.php
+++ b/tests/bench/src/Contenders/ThumbroVips.php
@@ -19,9 +19,8 @@ use MediaWiki\Extension\Thumbro\Bench\ToolLocator;
  * falling back to the image/webp block (so jpeg/webp share the webp save options while image/png
  * carries its own near-lossless block).
  *
- * GIF is the exception: its vips options are decided at runtime by LibwebpBackend (load options
- * forced to n=-1/1, or the whole transform handed to gif2webp), not by config, so this row models
- * the all-frames vips delegation explicitly.
+ * GIF is handled by {@see ThumbroGif} instead — its options are a runtime LibwebpBackend routing
+ * decision (gif2webp, or libvips with forced n), not a config lookup.
  */
 class ThumbroVips implements Contender {
 	/** MIMEs whose vips suffixes are derived from extension.json. */
@@ -32,7 +31,7 @@ class ThumbroVips implements Contender {
 	}
 
 	public function applies( string $mime ): bool {
-		return $mime === 'image/gif' || in_array( $mime, self::DERIVED, true );
+		return in_array( $mime, self::DERIVED, true );
 	}
 
 	public function isAvailable(): bool {
@@ -64,17 +63,13 @@ class ThumbroVips implements Contender {
 	/**
 	 * The vipsthumbnail "[..]" load/save suffixes Thumbro runs for $mime, derived from the given
 	 * ThumbroOptions config. Mirrors TransformOptionsResolver's libvips path: inputOptions from the
-	 * input-MIME block; outputOptions from the input-MIME block, else the image/webp block. GIF is
-	 * modeled explicitly (its vips options are a runtime LibwebpBackend decision, not config).
+	 * input-MIME block; outputOptions from the input-MIME block, else the image/webp block.
 	 *
 	 * @param string $mime input MIME type
 	 * @param array<string,array<string,mixed>> $thumbroOptions config.ThumbroOptions.value
 	 * @return array{0:string,1:string} [ inputSuffix, outputSuffix ]
 	 */
 	public static function optionsFor( string $mime, array $thumbroOptions ): array {
-		if ( $mime === 'image/gif' ) {
-			return [ '[n=-1]', '' ];
-		}
 		$input = $thumbroOptions[$mime]['inputOptions'] ?? [];
 		$output = $thumbroOptions[$mime]['outputOptions']
 			?? $thumbroOptions['image/webp']['outputOptions']

--- a/tests/bench/src/Orchestrator.php
+++ b/tests/bench/src/Orchestrator.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Thumbro\Bench;
 
 use MediaWiki\Extension\Thumbro\Bench\Contenders\GdBaseline;
 use MediaWiki\Extension\Thumbro\Bench\Contenders\ImageMagickBaseline;
+use MediaWiki\Extension\Thumbro\Bench\Contenders\ThumbroGif;
 use MediaWiki\Extension\Thumbro\Bench\Contenders\ThumbroVips;
 use RuntimeException;
 
@@ -16,7 +17,7 @@ class Orchestrator {
 
 	public function __construct() {
 		$this->baselines = [ new ImageMagickBaseline(), new GdBaseline() ];
-		$this->candidates = [ new ThumbroVips() ];
+		$this->candidates = [ new ThumbroVips(), new ThumbroGif() ];
 	}
 
 	/**

--- a/tests/bench/src/Ssimulacra2.php
+++ b/tests/bench/src/Ssimulacra2.php
@@ -95,8 +95,13 @@ class Ssimulacra2 {
 	}
 
 	/**
-	 * Extract candidate frames to PNGs. Single frame via convert [0]; animated WebP and
-	 * animated GIF both via convert -coalesce (no anim_dump dependency).
+	 * Extract candidate frames to full-canvas PNGs. Single frame via convert [0]; animated GIF
+	 * via convert -coalesce; animated WebP via libvips, page by page.
+	 *
+	 * The tool split matters: ImageMagick's -coalesce does NOT correctly reconstruct animated
+	 * WebP whose frames are stored as optimised partial/disposed regions (gif2webp output), so
+	 * the extracted PNGs come out mostly transparent and the metric craters (negative scores).
+	 * libvips's WebP loader composites each page to the full canvas, so it is used for WebP.
 	 *
 	 * @param string $candidate Path to candidate image
 	 * @param int $frameCount Expected number of frames (1 = static)
@@ -114,6 +119,9 @@ class Ssimulacra2 {
 			Subprocess::run( [ $convert, $candidate . '[0]', '-coalesce', '+repage', $dst ] );
 			return [ $dst ];
 		}
+		if ( self::isWebp( $candidate ) ) {
+			return self::extractWebpFrames( $candidate, $destDir );
+		}
 		Subprocess::run( [ $convert, $candidate, '-coalesce', '+repage', $destDir . '/cand_%03d.png' ] );
 		$frames = glob( $destDir . '/cand_*.png' ) ?: [];
 		sort( $frames );
@@ -121,5 +129,45 @@ class Ssimulacra2 {
 			throw new RuntimeException( 'No candidate frames extracted from ' . $candidate );
 		}
 		return $frames;
+	}
+
+	/**
+	 * Extract every page of an animated WebP to a full-canvas PNG via libvips (see
+	 * {@see self::extractFrames()} for why ImageMagick can't be used here).
+	 *
+	 * @return string[] frame PNG paths, index-ordered
+	 */
+	private static function extractWebpFrames( string $candidate, string $destDir ): array {
+		$vips = ToolLocator::require( 'vips', 'libvips-tools' );
+		$pages = self::webpPageCount( $candidate );
+		$frames = [];
+		for ( $i = 0; $i < $pages; $i++ ) {
+			$dst = sprintf( '%s/cand_%03d.png', $destDir, $i );
+			// `vips copy file.webp[page=N]` yields the composited full frame N.
+			$proc = Subprocess::run( [ $vips, 'copy', $candidate . "[page=$i]", $dst ] );
+			if ( !$proc->ok() || !is_file( $dst ) ) {
+				throw new RuntimeException( "vips failed extracting WebP frame $i from $candidate: " . $proc->stderr );
+			}
+			$frames[] = $dst;
+		}
+		if ( $frames === [] ) {
+			throw new RuntimeException( 'No candidate frames extracted from ' . $candidate );
+		}
+		return $frames;
+	}
+
+	/** Number of pages (frames) in an image, via vipsheader's n-pages field (>= 1). */
+	private static function webpPageCount( string $path ): int {
+		$vipsheader = ToolLocator::require( 'vipsheader', 'libvips-tools' );
+		$proc = Subprocess::run( [ $vipsheader, '-f', 'n-pages', $path ] );
+		return $proc->ok() ? max( 1, (int)trim( $proc->stdout ) ) : 1;
+	}
+
+	/** True if the file is a RIFF/WebP container (by magic bytes, not extension). */
+	public static function isWebp( string $path ): bool {
+		$header = (string)file_get_contents( $path, false, null, 0, 12 );
+		return strlen( $header ) >= 12
+			&& substr( $header, 0, 4 ) === 'RIFF'
+			&& substr( $header, 8, 4 ) === 'WEBP';
 	}
 }

--- a/tests/phpunit/unit/Bench/Ssimulacra2Test.php
+++ b/tests/phpunit/unit/Bench/Ssimulacra2Test.php
@@ -28,4 +28,19 @@ class Ssimulacra2Test extends MediaWikiUnitTestCase {
 		$this->expectException( \RuntimeException::class );
 		Ssimulacra2::parseScore( "no number here" );
 	}
+
+	public function testIsWebpDetectsByMagicBytesNotExtension(): void {
+		$webp = tempnam( sys_get_temp_dir(), 'thumbro_webp_' );
+		$gif = tempnam( sys_get_temp_dir(), 'thumbro_gif_' );
+		// RIFF<4-byte size>WEBP… vs GIF89a — extension-free, content only.
+		file_put_contents( $webp, "RIFF\x00\x00\x00\x00WEBPVP8X" );
+		file_put_contents( $gif, "GIF89a\x00\x00" );
+		try {
+			$this->assertTrue( Ssimulacra2::isWebp( $webp ) );
+			$this->assertFalse( Ssimulacra2::isWebp( $gif ) );
+		} finally {
+			unlink( $webp );
+			unlink( $gif );
+		}
+	}
 }

--- a/tests/phpunit/unit/Bench/ThumbroGifTest.php
+++ b/tests/phpunit/unit/Bench/ThumbroGifTest.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Unit\Bench;
+
+use MediaWiki\Extension\Thumbro\Backend\LibwebpBackend;
+use MediaWiki\Extension\Thumbro\Bench\Contenders\ThumbroGif;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Thumbro\Bench\Contenders\ThumbroGif
+ */
+class ThumbroGifTest extends MediaWikiUnitTestCase {
+
+	/**
+	 * The bench contender mirrors LibwebpBackend::chooseStrategy (the standalone harness can't
+	 * load the production class). This locks the two together across the entire truth table, so
+	 * the bench routing cannot silently drift from production.
+	 *
+	 * Scope: this guards the decision rule only, not how the inputs (animated / underThreshold /
+	 * hasTransparency) are derived — those derivations are verified against production by reading.
+	 */
+	public function testStrategyMatchesProductionAcrossTheTruthTable(): void {
+		foreach ( [ false, true ] as $animated ) {
+			foreach ( [ false, true ] as $underThreshold ) {
+				foreach ( [ false, true ] as $hasTransparency ) {
+					foreach ( [ false, true ] as $libwebpAvailable ) {
+						$bench = ThumbroGif::chooseStrategy(
+							$animated, $underThreshold, $hasTransparency, $libwebpAvailable );
+						$prod = LibwebpBackend::chooseStrategy(
+							$animated, $underThreshold, $hasTransparency, $libwebpAvailable );
+						$this->assertSame( $prod, $bench, sprintf(
+							'animated=%d underThreshold=%d transparency=%d libwebp=%d',
+							$animated, $underThreshold, $hasTransparency, $libwebpAvailable ) );
+					}
+				}
+			}
+		}
+	}
+
+	public function testStaticGifTakesTheFirstFrame(): void {
+		$this->assertSame( 'vips-static', ThumbroGif::chooseStrategy( false, true, false, true ) );
+	}
+
+	public function testTransparentAnimationUsesGif2webpWhenAvailable(): void {
+		$this->assertSame( 'libwebp', ThumbroGif::chooseStrategy( true, true, true, true ) );
+	}
+
+	public function testTransparentAnimationFallsBackToVipsWithoutGif2webp(): void {
+		$this->assertSame( 'vips-animated', ThumbroGif::chooseStrategy( true, true, true, false ) );
+	}
+
+	public function testOpaqueAnimationDelegatesToVips(): void {
+		$this->assertSame( 'vips-animated', ThumbroGif::chooseStrategy( true, true, false, true ) );
+	}
+
+	public function testOverThresholdAnimationFallsBackToStatic(): void {
+		$this->assertSame( 'vips-static', ThumbroGif::chooseStrategy( true, false, true, true ) );
+	}
+}

--- a/tests/phpunit/unit/Bench/ThumbroVipsTest.php
+++ b/tests/phpunit/unit/Bench/ThumbroVipsTest.php
@@ -15,7 +15,6 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 		'image/jpeg' => [ 'inputOptions' => [] ],
 		'image/png'  => [ 'inputOptions' => [], 'outputOptions' => [ 'near_lossless' => 'true', 'Q' => '60' ] ],
 		'image/webp' => [ 'inputOptions' => [], 'outputOptions' => [ 'strip' => 'true', 'Q' => '90' ] ],
-		'image/gif'  => [ 'inputOptions' => [ 'n' => '-1' ] ],
 	];
 
 	public function testPngUsesItsOwnOutputBlock(): void {
@@ -39,14 +38,6 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 		// Same rule as LibvipsBackend::makeOptions — keys are emitted in config order.
 		[ , $out ] = ThumbroVips::optionsFor( 'image/png', self::CONFIG );
 		$this->assertSame( '[near_lossless=true,Q=60]', $out );
-	}
-
-	public function testGifIsModeledExplicitlyNotFromConfig(): void {
-		// Even though the webp block has save options, GIF output stays empty: production
-		// decides GIF's vips options at runtime (LibwebpBackend), not via config.
-		[ $in, $out ] = ThumbroVips::optionsFor( 'image/gif', self::CONFIG );
-		$this->assertSame( '[n=-1]', $in );
-		$this->assertSame( '', $out );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two changes that make the benchmark harness measure Thumbro's GIF path the way
production actually runs it — and a finding that falls out once it does.

**1. Fix animated-WebP frame extraction** (`Ssimulacra2::extractFrames`).
ImageMagick's `convert -coalesce` cannot reconstruct animated WebP whose frames
are stored as optimised partial/disposed regions (gif2webp output) — extracted
frames come out mostly transparent, so SSIMULACRA2 returned garbage (negative
means). Animated-WebP extraction now goes through libvips (`vips copy file.webp[page=N]`,
which composites each page to the full canvas); animated GIF keeps `convert -coalesce`
(the ImageMagick baseline's own output, which it handles correctly). WebP is
detected by RIFF/WEBP magic bytes. On the transparent fixture this lifts the
candidate from a bogus **−3.5** to a real **39.4**.

**2. Add a faithful `ThumbroGif` contender.** The libvips contender modelled every
GIF as one vips call, so the dominant transparent-animated path (gif2webp) was never
exercised. `ThumbroGif` probes routing inputs at runtime exactly as production does
(frame count + transparency via `vipsheader`; area = w×h×frames, matching core
`GIFHandler::getImageArea`) and runs the real pipeline per fixture: gif2webp for
transparent animation under threshold, libvips animated WebP (n=−1) for opaque/
over-threshold, first frame (n=1) for static. Its routing mirrors
`LibwebpBackend::chooseStrategy` and is **locked to it by a truth-table test** across
all 16 input combinations (the standalone harness can't load the production class).
Encoder settings come from `extension.json`. GIF was removed from `ThumbroVips`.

## Harness results — all four axes

| fixture | strategy | size (IM → Thumbro) | SSIM2 | wall time | peak RSS |
|---|---|---|---|---|---|
| sprite 64px | vips-static | 157 → 978 B | 100 → 85.2 | 115 → **57** ms | 137 → **34** MB |
| sprite 120px | vips-static | 1453 → 2040 B | 62.2 → **93.7** | 86 → **63** ms | 137 → **37** MB |
| anim-small 84px (21f) | vips-animated | 7068 → 12032 B | 97.8 → 84.6 | 125 → **104** ms | 141 → **39** MB |
| anim-large 84px (31f) | vips-animated | 6203 → 9130 B | 98.1 → 80.0 | 784 → **253** ms | **272 → 48** MB |
| anim-transparent 84px (48f) | gif2webp | 36031 → 53838 B | 52.9 → 39.4 | 265 → 481 ms | **167 → 49** MB |

**Thumbro wins peak RSS on every case (3.4×–5.7× leaner) and wall time on 4 of 5**
(slower only on the gif2webp two-step). IM wins size on all 5 and quality on 4.

## Finding — a trade-off, not a loss

This is **INCOMPARABLE, not a clean loss**: IM dominates *size and quality* at these
sizes; Thumbro dominates *memory and time*. The gate reports "0 win / 1 trade-off /
4 loss" only because its dominance rule compares **size × quality alone** — it treats
performance as hard caps + soft *regression* flags, so it cannot credit a 5.7× memory
win. That's inconsistent with AGENTS.md, which names performance (wall time + peak RSS)
as one of the three axes Thumbro optimises. **Worth a gate-definition decision**:
should perf count toward dominance/incomparability? (orthogonal to this PR; affects all
handlers.)

The memory axis is the important one and it **scales**: ImageMagick's `convert -coalesce`
holds every frame at full canvas — 272 MB on the 700px/31f case already, growing with
frames × canvas (the earlier encoder investigation measured the IM-direct path at
185–377 MB, an OOM risk). Thumbro stays flat at ~50 MB. At this tiny corpus IM's RSS is
still under the 512 MB cap so it looks fine, but on production-scale animated GIFs IM
heads toward the cap while Thumbro doesn't.

**The corpus is too small to show Thumbro's biggest advantage** (≤120px, modest frame
counts). Larger/real-world GIF fixtures would likely flip the memory story from "nice"
to "decisive". Recommend adding them and re-benching before any conclusion about GIF
strategy/tuning.

## Tests & checks

- New: `ThumbroGifTest` (routing truth-table vs production + strategy cases),
  `Ssimulacra2Test::testIsWebpDetectsByMagicBytesNotExtension`.
- Thumbro unit suite: 82/82 green. phpcs: clean. (Phan can't run in the dev container
  — php-ast 1.1.2 < required 1.1.3+ — unrelated to this change.)
- Code-reviewed (subagent): no Critical/Important issues; the two actionable Minor
  items (config-faithful gif2webp load options; test-scope comment) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)