### PR TITLE
chore(bench): a scoring failure no longer aborts the whole benchmark run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,10 @@ GD where it is a real core path) on the three axes Thumbro optimises: **file siz
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `refactor:`)
 - Use `ci:` or `chore:` for non-user-facing changes (tooling, config, dependencies)
+- The benchmark harness (`tests/bench/`) is non-user-facing dev tooling: scope its commits
+  with `test:` or `chore:` (e.g. `test(bench):`), never `feat:`/`fix:`. release-please groups
+  the changelog by commit **type** (not scope) and hides `test`/`chore` by default, so the
+  type — not the `bench` scope — is what keeps these out of the release notes.
 
 ### i18n
 

--- a/tests/bench/src/Contenders/ThumbroGif.php
+++ b/tests/bench/src/Contenders/ThumbroGif.php
@@ -116,7 +116,8 @@ class ThumbroGif implements Contender {
 		$tmpGif = dirname( $dst ) . '/thumbro_resize_' . $targetWidth . '.gif';
 		// Load options are the configured gif block's (production's planLibwebpEncode uses
 		// inputOptions() verbatim here, unlike the delegation paths which force n at runtime).
-		$resize = [ $vips, $srcPath . self::makeOptions( $cfg['gifInput'] ), '--size', $targetWidth . 'x100000', '-o', $tmpGif ];
+		$in = $srcPath . self::makeOptions( $cfg['gifInput'] );
+		$resize = [ $vips, $in, '--size', $targetWidth . 'x100000', '-o', $tmpGif ];
 		$p1 = Subprocess::run( $resize );
 		if ( !$p1->ok() || !is_file( $tmpGif ) ) {
 			return Result::unavailable( $this->name(), $srcPath, $targetWidth, 'vips resize failed: ' . $p1->stderr );

--- a/tests/bench/src/Orchestrator.php
+++ b/tests/bench/src/Orchestrator.php
@@ -58,7 +58,7 @@ class Orchestrator {
 		foreach ( $applicableBaselines as $b ) {
 			$res = $b->run( $entry['path'], $mime, $w, $dir );
 			$baseResults[$b->name()] = $res;
-			$baseQualities[$b->name()] = $res->available ? $this->scoreQuality( $res, $entry, $dir ) : null;
+			$baseQualities[$b->name()] = $res->available ? $this->tryScoreQuality( $res, $entry, $dir ) : null;
 		}
 
 		// Representative fixtures drive the dominance go/no-go; stress fixtures are checked
@@ -70,7 +70,7 @@ class Orchestrator {
 				continue;
 			}
 			$res = $c->run( $entry['path'], $mime, $w, $dir );
-			$quality = $res->available ? $this->scoreQuality( $res, $entry, $dir ) : null;
+			$quality = $res->available ? $this->tryScoreQuality( $res, $entry, $dir ) : null;
 			$verdicts = [];
 			$capsVerdict = null;
 			if ( $res->available && $quality !== null ) {
@@ -103,6 +103,25 @@ class Orchestrator {
 			'baselines' => $baseResults, 'baselineQualities' => $baseQualities,
 			'candidates' => $candResults, 'dir' => $dir,
 		];
+	}
+
+	/**
+	 * Score quality, degrading to null on a scoring failure instead of aborting the whole run.
+	 * A contender that flattens an animated source (candidate frame count != reference frame
+	 * count) makes the metric throw; that one cell is left unscored and reported as such, while
+	 * the rest of the corpus still runs. A single bad fixture/contender must never crash the suite.
+	 *
+	 * @param Result $res
+	 * @param array{path:string,mime:string,tier:string,animated:bool,frames:int,targets:int[]} $entry
+	 */
+	private function tryScoreQuality( Result $res, array $entry, string $dir ): ?Quality {
+		try {
+			return $this->scoreQuality( $res, $entry, $dir );
+		} catch ( RuntimeException $e ) {
+			fwrite( STDERR, sprintf( "  warning: could not score %s on %s @%dpx: %s\n",
+				$res->contender, basename( $entry['path'] ), $res->targetWidth, $e->getMessage() ) );
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem

A single contender that flattens an animated source (candidate frame count !=
reference frame count) makes SSIMULACRA2 scoring throw `Frame count mismatch`,
which propagated out of `Orchestrator` and **aborted the entire benchmark run** —
one bad fixture/contender killed the whole suite.

This currently breaks the `--mime=image/webp` and full runs on `main`: the
`anim.webp` representative fixture exists, but the fix that makes Thumbro animate
WebP (PR #69) isn't merged yet, so the contender flattens it → mismatch → abort.

## Fix

Wrap per-cell quality scoring in `Orchestrator` (`tryScoreQuality`): on a
`RuntimeException`, log a warning to STDERR, leave that cell **unscored** (quality
null — the reporter shows `-`, no verdict / no caps line), and continue the run. A
single bad fixture or contender can no longer crash the suite.

Verified on `main`'s current corpus:
```
warning: could not score thumbro-vips on anim.webp @250px: Frame count mismatch: ref=44 cand=1
... run completes (exit 0), all other fixtures scored ...
```

Also wraps one `ThumbroGif` line that exceeded 120 chars — a phpcs *warning* that
slipped through an un-re-linted amend in #67 (warnings don't fail phpcs's exit).

## Tests
- Bench unit suite green (39 tests). phpcs clean.
- Behavioural verification: the WebP run that previously aborted now completes with
  the warning above and scores every other fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)