### PR TITLE
ci: hide chore/test/etc. from the release changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,10 @@ GD where it is a real core path) on the three axes Thumbro optimises: **file siz
 - Use `ci:` or `chore:` for non-user-facing changes (tooling, config, dependencies)
 - The benchmark harness (`tests/bench/`) is non-user-facing dev tooling: scope its commits
   with `test:` or `chore:` (e.g. `test(bench):`), never `feat:`/`fix:`. release-please groups
-  the changelog by commit **type** (not scope) and hides `test`/`chore` by default, so the
-  type — not the `bench` scope — is what keeps these out of the release notes.
+  the changelog by commit **type** (not scope), so the type — not the `bench` scope — is what
+  keeps these out of the release notes. The hidden types are set explicitly in
+  `release-please-config.json` (`changelog-sections`): `test`, `chore`, `docs`, `refactor`,
+  `style`, `build`, `ci` are hidden; `feat`, `fix`, `perf`, `revert` show.
 
 ### i18n
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,19 @@
 		"package.json",
 		"package-lock.json"
 	],
+	"changelog-sections": [
+		{ "type": "feat", "section": "Features" },
+		{ "type": "fix", "section": "Bug Fixes" },
+		{ "type": "perf", "section": "Performance Improvements" },
+		{ "type": "revert", "section": "Reverts" },
+		{ "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+		{ "type": "docs", "section": "Documentation", "hidden": true },
+		{ "type": "style", "section": "Styles", "hidden": true },
+		{ "type": "refactor", "section": "Code Refactoring", "hidden": true },
+		{ "type": "test", "section": "Tests", "hidden": true },
+		{ "type": "build", "section": "Build System", "hidden": true },
+		{ "type": "ci", "section": "Continuous Integration", "hidden": true }
+	],
 	"packages": {
 		".": {}
 	}


### PR DESCRIPTION
## Why

release-please groups the changelog by commit **type**, not scope — there's no way to
exclude a `bench` *scope*. In this repo's setup `chore` is **not** hidden by default: the
1.3.0 release PR (#58) listed `chore(bench): a scoring failure…` under "Miscellaneous
Chores", so non-user-facing harness changes still leaked into the release notes.

## What

Add an explicit `changelog-sections` to `release-please-config.json`:
- **Shown:** `feat`, `fix`, `perf`, `revert`
- **Hidden:** `chore`, `docs`, `style`, `refactor`, `test`, `build`, `ci`

So benchmark-harness commits (`test(bench):` / `chore(bench):`) — and other tooling
changes — stay out of the changelog regardless of type. Also corrects the AGENTS.md note
that wrongly said `chore` was hidden by default.

## Note on 1.3.0 (#58)

Once this merges, release-please regenerates #58 and the `chore(bench)` line drops. One
entry remains: `fix(bench): extract animated WebP frames…` (from #67, already merged as
type `fix`, which is correctly shown) — that was a mis-typed bench commit before this
convention existed. It can be trimmed from the 1.3.0 notes by hand if desired; future
bench commits won't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on how commit types control changelog visibility.

* **Chores**
  * Configured changelog section mappings for consistent release note generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->