### PR TITLE
docs: close out flat-graphic PNG follow-up (accepted format trade-off)

### DIFF
--- a/docs/adr/0001-image-benchmark-gate.md
+++ b/docs/adr/0001-image-benchmark-gate.md
@@ -117,12 +117,11 @@ cross-link to it. This ADR is the first.
 
 ### Follow-ups (explicitly NOT in this change's scope)
 
-- **Re-validate every per-MIME option** (JPEG q90, PNG near-lossless) against the new
-  gate + corpus + widths; the knees may shift. Run the new gate once to capture a new
-  baseline-of-record — current options may read INCOMPARABLE until the follow-up re-tunes
-  them. This is the immediate next PR.
+- **Re-validate every per-MIME option** against the new gate + corpus + widths. *Done:* JPEG
+  re-tuned Q90 → Q80; PNG re-validated and kept. See `docs/encoding/`.
 - **Regenerate GD numbers** and revisit prior GD claims (now migrated to `docs/encoding/`),
-  since earlier GD results came from a contender that did not match MediaWiki's GD path.
-- **Pre-existing issues** documented but not fixed here: `flat-graphic.png` losing to
-  ImageMagick (PNG near-lossless on a flat graphic); `anim-transparent.gif` breaching the
-  quality floor.
+  since earlier GD results came from a contender that did not match MediaWiki's GD path. *Done.*
+- **Pre-existing issues:** `flat-graphic.png` losing to ImageMagick — *investigated and
+  accepted* as a fundamental format limit (PNG palette beats WebP on 2-colour content; sub-KB,
+  visually equivalent); see `docs/encoding/image-png.md`. `anim-transparent.gif` breaching the
+  quality floor — *still open.*

--- a/docs/encoding/image-png.md
+++ b/docs/encoding/image-png.md
@@ -55,11 +55,16 @@ outright (40–50% smaller). The trade-offs are content outside its strength —
   lower-quality than ImageMagick at 180/250 (wins at 400). Accepted: graphics/transparency
   is PNG's dominant real use; the photographic-PNG case is secondary, and re-tuning toward it
   would forfeit the large logo/UI wins.
-- **`flat-graphic.png`: near-lossless can't beat lossless PNG on a flat-colour graphic
-  (pre-existing, tracked).** At 250px it is larger and lower-quality than both ImageMagick and
-  GD — a loss vs the binding baseline *and* a GD floor breach. At 400px it wins vs ImageMagick
-  but is still larger than GD's tiny PNG (a second GD floor breach). Documented as a
-  pre-existing follow-up in ADR-0001 (not introduced by the gate redesign or the JPEG re-tune).
+- **`flat-graphic.png` (2-colour): accepted format trade-off.** Ultra-low-colour graphics are
+  where PNG's palette/lossless compression is unbeatable — IM's PNG is 3.0 KB, GD's just 2.0 KB,
+  and even *lossless* WebP is ~98% larger. near-lossless is the best WebP can do here: at 250px
+  it is ~0.4 KB larger and lower-quality than IM (a loss + GD floor breach); at 400px it wins
+  vs IM but stays larger than GD's tiny PNG (a GD floor breach). **Investigated and accepted**
+  (ADR-0001 follow-up): the difference is sub-KB and visually indistinguishable at thumbnail
+  scale — the SSIMULACRA2 gap does not show as edge artifacts — and no WebP profile wins it
+  without regressing the logo / UI / transparency cases that are PNG's primary use (lossless
+  drops the whole tier to 7 win / 2 loss). A content-aware path (emit PNG for near-binary
+  content) was weighed and rejected as over-engineering for an invisible, sub-KB difference.
 
 **Performance:** all cells well under the hard caps (peak RSS ≤ ~85 MB, wall time < 0.5 s)
 — near-lossless raises peak RSS at small sizes. Generation cost is paid once and cached.


### PR DESCRIPTION
## Summary

Closes out the `flat-graphic.png` PNG follow-up from ADR-0001 — **as an accepted format trade-off, not a code fix** (investigated, no good fix exists).

`flat-graphic.png` is a **2-colour** image, where PNG's palette/lossless compression is unbeatable (IM 3.0 KB, GD 2.0 KB). Findings:

- **No WebP profile wins it.** Tested on the current corpus: lossless WebP is ~98% *larger* (and drops the whole PNG tier to 7 win / 2 loss); near-lossless Q80 is also worse. `near_lossless Q60` stays the best PNG profile (8 win / 3 trade-off / 1 loss).
- **The difference is invisible.** At 250px (full + 3× edge crop), the near-lossless WebP is indistinguishable from MediaWiki's PNG — the SSIMULACRA2 gap (87.0 vs 92.8) doesn't show as edge artifacts, and it's only ~0.4 KB larger.
- A content-aware path (emit PNG for near-binary input) was weighed and **rejected** as over-engineering for a sub-KB, invisible difference on rare content.

No runtime change — `image/png` keeps `near_lossless Q60`. Docs only: `image-png.md` reframes the note as an accepted trade-off with the root cause + verification; ADR-0001's follow-up list is updated (flat-graphic resolved; `anim-transparent.gif` floor breach still open).

## Test plan
- [x] Docs only; no code or config change. (PNG profile unchanged → gate results unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
