### PR TITLE
docs: add image/gif and image/webp encoding profile records

### DIFF
--- a/docs/encoding/README.md
+++ b/docs/encoding/README.md
@@ -18,10 +18,13 @@ change whenever a sweep finds a better option set.
 Numbers come from `tests/bench/benchmark.php` against the corpus; the live profiles are in
 `extension.json`.
 
-| MIME | Profile | Output |
-| --- | --- | --- |
-| [image/jpeg](image-jpeg.md) | `Q=80, smart_subsample=false, effort=6, strip` | WebP |
-| [image/png](image-png.md) | `near_lossless, Q=60, strip` | WebP (near-lossless) |
+| MIME | Profile | Output | Baseline |
+| --- | --- | --- | --- |
+| [image/jpeg](image-jpeg.md) | `Q=80, smart_subsample=false, effort=6, strip` | WebP | IM (+ GD floor) |
+| [image/png](image-png.md) | `near_lossless, Q=60, strip` | WebP (near-lossless) | IM (+ GD floor) |
+| [image/gif](image-gif.md) | `libwebp`/gif2webp `mixed, q=80, m=4` (routed; see file) | WebP (anim / static) | IM only |
+| [image/webp](image-webp.md) | `Q=90, smart_subsample=true, strip` (also the shared fallback) | WebP | none |
 
-(`image/webp` source has no MediaWiki baseline to gate against; `image/gif` uses the
-libwebp/animation path — neither has a tuning record yet.)
+Baseline = which MediaWiki default scaler the gate compares against. `image/webp` input has no
+MediaWiki baseline, so it is documented but not dominance-tested; `image/gif` has no GD path
+(ImageMagick only).

--- a/docs/encoding/image-gif.md
+++ b/docs/encoding/image-gif.md
@@ -1,0 +1,64 @@
+# image/gif — encoding profile
+
+**Backend:** `libwebp` (`gif2webp`), with `inputOptions: { "n": "-1" }` (read all frames).
+gif2webp flags (`ThumbroLibraries.libwebp.flags`): `{ "mixed": "", "q": "80", "m": "4" }`.
+Output format: **WebP** (animated, or a static first frame). **Status:** active (2026-06-06).
+
+## Routing
+
+Unlike the other MIMEs, GIF has no single `outputOptions` block — the `Libwebp` backend owns
+the runtime policy (see `AGENTS.md` → "Media handlers"):
+
+- **Transparent animated GIF** under `$wgThumbroMaxAnimatedArea` (with `gif2webp` present) →
+  encoded by **gif2webp** (`mixed` lossy/lossless, `q=80`, `m=4`). gif2webp handles per-frame
+  alpha efficiently — this is the path that avoids the libvips animated-WebP alpha blow-up.
+- **Opaque animated GIF**, and the **gif2webp-unavailable fallback** → delegated to **libvips**
+  as animated WebP (all frames preserved; uses the shared `image/webp` save options).
+- **Static GIF**, and **animation over the threshold** → delegated to **libvips** as a static
+  first frame.
+
+## How it compares to MediaWiki
+
+Each cell is **size / quality** (SSIMULACRA2, 0–100, higher is better). ImageMagick is the
+binding baseline; it outputs **GIF** (256-colour palette). **GD has no animated-GIF path, so
+it is not a baseline for this MIME** (no floor row). Thumbro outputs WebP.
+
+| Image · width | ImageMagick (GIF) | Thumbro (WebP) | Result |
+| --- | --- | --- | --- |
+| sprite · 120px | 5.6 KB / 42.9 | 8.1 KB / 73.0 | ~ trade-off |
+| sprite · 250px | 16.4 KB / 33.7 | 23.3 KB / 52.0 | ~ trade-off |
+| anim-opaque · 250px (44f) | 669.6 KB / 80.9 | **250.9 KB / 84.9** | ✅ win |
+
+✅ **win** — smaller at no-worse quality · ~ **trade-off** — see note · ✗ **loss** — bigger and no better
+
+The animation win is the headline: **63% smaller at higher quality** than ImageMagick's
+coalesced GIF. The sprite trade-offs are favourable — Thumbro is larger but *dramatically*
+higher quality (73.0 vs 42.9, 52.0 vs 33.7), because ImageMagick's 256-colour palette GIF
+bands badly on the rasterised sprite while Thumbro's WebP does not. Numbers from
+`tests/bench/benchmark.php`.
+
+## Accepted trade-offs
+
+- **`sprite.gif` (static): larger than ImageMagick, but far higher quality.** A small
+  rasterised icon; Thumbro's WebP is ~40% larger yet visually much cleaner than IM's
+  palette-banded GIF. Accepted — the size delta is small (single-digit KB) and the quality
+  gain is large.
+- **Transparent animation (stress):** `anim-transparent.gif` exercises the gif2webp alpha
+  path. Quality is **advisory** on the stress tier (SSIMULACRA2 is unreliable on tiny
+  transparent animation — see `tests/bench/README.md`); the real guards are size/time/RSS,
+  which pass with room to spare (no blow-up).
+
+**Performance:** within the hard caps (animated time ceiling 10 s, RSS 512 MB) — animated GIFs
+peak well under both (e.g. anim-opaque ~66 MB / ~0.45 s vs ImageMagick's ~198 MB).
+
+## History
+
+- **2026-06-06 — measured** on the redesigned gate (ADR-0001); routing/flags unchanged,
+  numbers recorded. The gif2webp flags were **not** swept: they affect only the
+  transparent-animation path (a stress fixture with advisory quality), and the representative
+  cells are governed by the shared `image/webp` block — so there is little gif-specific tuning
+  headroom. gif2webp policy and the libvips-delegation seam landed earlier (PR #57).
+
+## Reproduce
+
+`php tests/bench/benchmark.php --mime=image/gif` (see `tests/bench/README.md`).

--- a/docs/encoding/image-webp.md
+++ b/docs/encoding/image-webp.md
@@ -1,0 +1,50 @@
+# image/webp — encoding profile
+
+**Current profile** (`extension.json` → `ThumbroOptions["image/webp"].outputOptions`):
+
+```json
+{ "strip": "true", "Q": "90", "smart_subsample": "true" }
+```
+
+Output format: **WebP** (re-encode + downscale). **Status:** active (2026-06-06).
+
+## Rationale
+
+A WebP source is downscaled and re-encoded to WebP. Q is kept high (90) with
+`smart_subsample` on — a conservative, general-purpose profile: re-encoding already-compressed
+WebP shouldn't add much loss, and `smart_subsample` protects sharp chroma edges (a WebP source
+may be a graphic or a screenshot, not just a photo).
+
+This block doubles as the **shared fallback**: any MIME whose own block is absent inherits
+these save options, and the GIF → libvips delegation (opaque / over-threshold animation) uses
+them too. So changing it affects more than WebP input — see `image-gif.md`.
+
+## No baseline (not dominance-tested)
+
+There is **no comparison table here.** MediaWiki's default scalers don't emit WebP, and the
+benchmark has no WebP baseline contender — neither ImageMagick nor GD applies to WebP *input*
+— so `image/webp` has no win/loss verdict against MediaWiki. The harness still renders the
+thumbnail and tracks its quality (vs the lossless vips reference) for sanity, and the stress
+caps apply, but this MIME is not gate-validated for "improvement over MediaWiki" the way
+JPEG/PNG/GIF are.
+
+Thumbro's own measurements (no baseline; for reference / regression-tracking):
+
+| Image · width | Thumbro (WebP) |
+| --- | --- |
+| photo.webp · 180px | 26.9 KB / 79.3 |
+| photo.webp · 250px | 38.4 KB / 87.8 |
+| photo.webp · 400px | 68.5 KB / 86.8 |
+| anim.webp · 250px (44f) | 223.8 KB / 84.8 |
+
+Size / SSIMULACRA2. Performance well within the hard caps (peak RSS ≤ ~95 MB, wall time < 1 s).
+
+## History
+
+- **2026-06-06 — measured** on the redesigned gate (ADR-0001); profile unchanged. It has no
+  baseline to validate against (see above) and is the shared WebP/fallback block, so it is
+  recorded, not tuned.
+
+## Reproduce
+
+`php tests/bench/benchmark.php --mime=image/webp` (see `tests/bench/README.md`).


### PR DESCRIPTION
## Summary

Completes the per-MIME encoding docs under `docs/encoding/` (the coverage gap noted after the gate work). Docs only — no code/config change.

- **`image-gif.md`** — documents the `libwebp`/gif2webp routing (transparent animation → gif2webp; opaque animation + fallback → libvips animated WebP; static / over-threshold → libvips static first frame) and a comparison vs **ImageMagick** (GD has no animated-GIF path, so there's no GD floor for this MIME). `anim-opaque` wins 63% smaller at higher quality; the static `sprite` is a favourable trade-off (larger but far higher quality than IM's 256-colour palette GIF).
- **`image-webp.md`** — documents the `Q=90, smart_subsample=true` profile, which is also the **shared fallback** block (and feeds the GIF→libvips delegation). Explains that **no MediaWiki baseline applies to WebP input** (ImageMagick/GD don't process WebP source), so this MIME is documented but **not dominance-tested**; Thumbro's own size/quality numbers are recorded for regression-tracking.
- **README index** gains a `Baseline` column and rows for gif (IM only) and webp (none).

## Test plan
- [x] Docs only; no code or config change (gate results unchanged). Numbers sourced from `benchmark.php --mime=image/gif` and `--mime=image/webp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
