### PR TITLE
Encode static WebP thumbnails with cwebp (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,69 +34,75 @@ wfLoadExtension( 'Thumbro' );
 > ℹ️ **Thumbro works out of the box — no configuration required.**
 
 ### `$wgThumbroLibraries`
-The image libraries Thumbro can use, and how to run each.
+The image tools Thumbro can run, and the path to each binary.
 
 Key | Description
 :--- | :---
-`command` | Path to the library's executable
-`flags` | Optional encoder flags for the library, passed straight through (libwebp → [`gif2webp`](https://developers.google.com/speed/webp/docs/gif2webp), e.g. `mixed`, `q`, `m`)
+`command` | Path to the tool's executable
 
 Default:
 ```php
 $wgThumbroLibraries = [
-	'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ],
-	'libwebp' => [
-		'command' => '/usr/bin/gif2webp',
-		'flags' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ]
-	],
+	'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ], // resize (+ vips-webp encode)
+	'libwebp' => [ 'command' => '/usr/bin/gif2webp' ],      // animated-GIF encode
+	'cwebp'   => [ 'command' => '/usr/bin/cwebp' ],         // static-WebP encode
 ];
 ```
 
 ### `$wgThumbroOptions`
-Controls how each file type is thumbnailed: which library handles it, and the options passed to that library. The defaults are tuned per format, so most wikis never need to change this.
+Controls how each file type is thumbnailed as a **resize → encode** pipeline. The defaults are tuned per format, so most wikis never need to change this.
+
+Each MIME block has:
 
 Key | Description
 :--- | :---
 `enabled` | Turn Thumbro on or off for this file type
-`library` | Which library handles this type (a key from `$wgThumbroLibraries`)
-`inputOptions` | Options for loading and resizing the source image
-`outputOptions` | WebP save options ([`VipsForeignSave`](https://www.libvips.org/API/current/VipsForeignSave.html)), e.g. `Q`, `strip`, `smart_subsample`. Set per file type; if omitted, the `image/webp` block's options apply. (gif2webp's encoder flags live on the `libwebp` library, not here.)
+`minArea` / `maxArea` | Optional: only handle sources whose area (px²) is within range
+`resize` | The resize stage: `{ "options": { … } }` — libvips load/resize options
+`encode` | An ordered list of encoder choices. Each entry is `{ "encoder", "when"?, "options" }`. The first entry whose `when` capability guard the file satisfies is used; an entry with no `when` is the catch-all (put it last). Each encoder owns its own `options`.
 
-Default:
+Encoders: `vips-webp` (libvips webpsave — also handles animation), `cwebp` (libwebp, static only — more byte-efficient), `gif2webp` (libwebp, animated). `when` guards match the file's capabilities: `animated`, `alpha` (transparency), `underThreshold` (area ≤ `$wgThumbroMaxAnimatedArea`).
+
+Default (abridged):
 ```php
 $wgThumbroOptions = [
-	'image/gif' => [
+	// Static WebP → cwebp (smaller); animated WebP → vips; vips catch-all if cwebp is absent.
+	'image/webp' => [
 		'enabled' => true,
-		'library' => 'libwebp',
-		'inputOptions' => [
-			'n' => '-1'
-		]
+		'resize'  => [ 'options' => [] ],
+		'encode'  => [
+			[ 'encoder' => 'vips-webp', 'when' => [ 'animated' => true ],
+			  'options' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ] ],
+			[ 'encoder' => 'cwebp', 'options' => [ 'q' => '80', 'm' => '6' ] ],
+			[ 'encoder' => 'vips-webp',
+			  'options' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ] ],
+		],
 	],
 	'image/jpeg' => [
 		'enabled' => true,
-		'library' => 'libvips',
-		'inputOptions' => []
+		'resize'  => [ 'options' => [] ],
+		'encode'  => [ [ 'encoder' => 'vips-webp',
+			'options' => [ 'strip' => 'true', 'Q' => '80', 'smart_subsample' => 'false', 'effort' => '6' ] ] ],
 	],
 	'image/png' => [
 		'enabled' => true,
-		'library' => 'libvips',
-		'inputOptions' => [],
-		'outputOptions' => [
-			'near_lossless' => 'true',
-			'Q' => '60',
-			'strip' => 'true'
-		]
+		'resize'  => [ 'options' => [] ],
+		'encode'  => [ [ 'encoder' => 'vips-webp',
+			'options' => [ 'near_lossless' => 'true', 'Q' => '60', 'strip' => 'true' ] ] ],
 	],
-	'image/webp' => [
+	// GIF: transparent animation → gif2webp; opaque animation → vips animated; else vips first-frame.
+	'image/gif' => [
 		'enabled' => true,
-		'library' => 'libvips',
-		'inputOptions' => [],
-		'outputOptions' => [
-			'strip' => 'true',
-			'Q' => '90',
-			'smart_subsample' => 'true'
-		]
-	]
+		'resize'  => [ 'options' => [] ],
+		'encode'  => [
+			[ 'encoder' => 'gif2webp', 'when' => [ 'animated' => true, 'alpha' => true, 'underThreshold' => true ],
+			  'options' => [ 'mixed' => '', 'q' => '80', 'm' => '4' ] ],
+			[ 'encoder' => 'vips-webp', 'when' => [ 'animated' => true, 'underThreshold' => true ],
+			  'options' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ] ],
+			[ 'encoder' => 'vips-webp',
+			  'options' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ] ],
+		],
+	],
 ];
 ```
 
@@ -126,5 +132,5 @@ $wgThumbroEnabled = false;
 ## Requirements
 * [MediaWiki](https://www.mediawiki.org) 1.43.0 or later
 * **[libvips](https://www.libvips.org)** (8.14 or later; older versions may work but are untested) — required. Drives core thumbnail generation via the `vipsthumbnail` command.
-* **[libwebp](https://developers.google.com/speed/webp/docs/gif2webp)** (the `gif2webp` tool; Debian/Ubuntu `webp` package) — recommended. Encodes animated GIFs to compact animated WebP, far smaller than libvips for transparent animations. Without it, animated GIFs fall back to libvips automatically.
+* **[libwebp](https://developers.google.com/speed/webp/docs/using)** (the `cwebp` and `gif2webp` tools; Debian/Ubuntu `webp` package) — recommended. `cwebp` encodes static WebP thumbnails more compactly than libvips; `gif2webp` encodes animated GIFs to compact animated WebP, far smaller than libvips for transparent animations. Without it, both fall back to libvips automatically.
 * [Imagick](https://github.com/Imagick/imagick) — optional. Powers the detailed comparison statistics on Special:ThumbroTest.

--- a/docs/encoding/image-jpeg.md
+++ b/docs/encoding/image-jpeg.md
@@ -70,6 +70,9 @@ JPEG is very efficient at small high-quality sizes — but they are still wins, 
 
 ## History
 
+- **2026-06-07 — cwebp evaluated, vips-webp kept.** Phase 2 swept libwebp `cwebp` for static
+  raster; on JPEG cwebp ties vips-webp at matched quality (no win), so JPEG stays vips-webp.
+  (cwebp was adopted for WebP input only — see `image-webp.md`.)
 - **2026-06-06 — Q80** (this profile). Re-tuned on the redesigned gate + 4K corpus
   (ADR-0001). JPEG went from 2 win / 4 trade-off / 3 loss (Q90 on the new corpus) to
   6 win / 3 trade-off / 0 loss.

--- a/docs/encoding/image-png.md
+++ b/docs/encoding/image-png.md
@@ -71,6 +71,10 @@ outright (40–50% smaller). The trade-offs are content outside its strength —
 
 ## History
 
+- **2026-06-07 — cwebp evaluated, vips-webp kept.** Phase 2 swept libwebp `cwebp` for static
+  raster; on PNG cwebp loses badly (catastrophic on screenshots/line-art, and cannot reach IM
+  quality on the transparent logo even at q90), so PNG keeps vips-webp (`near_lossless`). (cwebp
+  was adopted for WebP input only — see `image-webp.md`.)
 - **2026-06-06 — re-validated, kept** on the redesigned gate + 4K corpus (ADR-0001). No
   change to the profile; numbers regenerated against the corrected gate.
 - **2026-06-06 — near_lossless, Q60** (PR #64). First dedicated PNG profile.

--- a/docs/encoding/image-webp.md
+++ b/docs/encoding/image-webp.md
@@ -1,81 +1,86 @@
 # image/webp — encoding profile
 
-**Current profile** (`extension.json` → the `vips-webp` entry's `options` in `ThumbroOptions["image/webp"].encode`):
+**Current profile** (`extension.json` → `ThumbroOptions["image/webp"].encode`):
 
-```json
-{ "strip": "true", "Q": "90", "smart_subsample": "true" }
-```
+- **Static** WebP → **cwebp** (libwebp): `{ "q": "80", "m": "6" }` (vips resizes; cwebp encodes).
+- **Animated** WebP → **vips-webp**: `{ "strip": "true", "Q": "90", "smart_subsample": "true" }`
+  (cwebp cannot encode animation).
 
-Output format: **WebP** (re-encode + downscale). **Status:** active (2026-06-06).
+Output format: **WebP**. **Status:** active (2026-06-07).
 
 ## Rationale
 
-A WebP source is downscaled and re-encoded to WebP. Q is kept high (90) with
-`smart_subsample` on — a conservative, general-purpose profile: re-encoding already-compressed
-WebP shouldn't add much loss, and `smart_subsample` protects sharp chroma edges (a WebP source
-may be a graphic or a screenshot, not just a photo).
+A WebP source is downscaled (always by libvips) and re-encoded to WebP. The encoder is split by
+animation:
 
-This block doubles as the **shared fallback**: any MIME whose own block is absent inherits
-these save options, and the GIF → libvips delegation (opaque / over-threshold animation) uses
-them too. So changing it affects more than WebP input — see `image-gif.md`.
+- **Static → cwebp.** libwebp's `cwebp` is markedly more byte-efficient than libvips `webpsave`
+  on the same pixels at the same quality (measured ~2× smaller at tied SSIMULACRA2). At **q80** it
+  is the encoder that turns WebP from a size *trade-off* into a clean gate **win** (see below): it
+  is smaller than ImageMagick at no-worse quality *and* smaller than the GD floor. (q84+ would
+  breach the GD floor on the larger sizes; q80 is the floor-safe knee.)
+- **Animated → vips-webp.** cwebp is single-image only; animated WebP keeps the libvips path
+  (`Q=90`, all frames). A `vips-webp` catch-all also covers a missing cwebp binary, so static WebP
+  degrades gracefully to libvips when libwebp is absent.
+
+The `vips-webp` entries here remain the **shared webpsave fallback** the GIF → libvips delegation
+uses (opaque / over-threshold animation) — see `image-gif.md`. cwebp is webp-static-only and is
+not a fallback for other MIMEs.
 
 ## How it compares to MediaWiki
 
-A WebP *source* keeps its format through the pipeline, so MediaWiki's own scalers do apply
-here: with `$wgUseImageMagick = true` ImageMagick re-encodes the WebP (the binding baseline),
-and the out-of-the-box GD default decodes/re-encodes a *static* WebP (the floor). The IM WebP
-baseline takes **no explicit `-quality`** (IM's default), faithfully representing an
-unconfigured install; only the JPEG baseline pins a quality. The GD floor writes WebP at
-**Q80** (`imagewebp(..., 80)`), mirroring GD's JPEG floor — GD has no "default" to fall back on
-the way IM does, so a fixed quality is used. Each cell is **size / quality** (SSIMULACRA2,
-0–100, higher is better). ImageMagick and GD output WebP; so does Thumbro.
+A WebP *source* keeps its format through the pipeline, so MediaWiki's own scalers apply: with
+`$wgUseImageMagick = true` ImageMagick re-encodes the WebP (binding baseline, no explicit
+`-quality`), and the out-of-the-box GD default decodes/re-encodes a *static* WebP (floor, written
+at Q80). Each cell is **size / quality** (SSIMULACRA2, 0–100, higher is better).
 
 | Image · width | ImageMagick | GD | Thumbro | Result |
 | --- | --- | --- | --- | --- |
-| photo.webp · 180px | 20.5 KB / 71.8 | 8.7 KB / 74.1 | 26.9 KB / 79.3 | ~ trade-off |
-| photo.webp · 250px | 25.9 KB / 73.9 | 15.1 KB / 79.3 | 38.4 KB / 87.8 | ~ trade-off |
-| photo.webp · 400px | 42.9 KB / 72.8 | 35.0 KB / 78.6 | 68.5 KB / 86.8 | ~ trade-off |
+| photo.webp · 180px | 20.5 KB / 71.8 | 8.7 KB / 74.1 | **8.3 KB / 73.8** | ✅ win |
+| photo.webp · 250px | 25.9 KB / 73.9 | 15.1 KB / 79.3 | **14.4 KB / 78.7** | ✅ win |
+| photo.webp · 400px | 42.9 KB / 72.8 | 35.0 KB / 78.6 | **33.1 KB / 78.1** | ✅ win |
 | anim.webp · 250px (44f) | 125.2 KB / 64.3 | — (animated) | 223.8 KB / 84.8 | ~ trade-off |
 
-✅ **win** — smaller at no-worse quality · ~ **trade-off** — *here, larger but higher quality* (the
-opposite direction from the jpeg/gif docs' smaller-but-lower-quality trade-offs); see note ·
-✗ **loss** — bigger and no better
+✅ **win** — smaller at no-worse quality · ~ **trade-off** — see note · ✗ **loss** — bigger and no better
 
-**Tally: 0 win · 4 trade-off · 0 loss.** Every cell is the *same* trade-off: Thumbro is larger
-but markedly higher quality (+7.5 to +20.5 SSIMULACRA2). The current profile re-encodes at a high
-Q (90), so for an already-compressed WebP source it buys quality at the cost of size rather
-than the smaller-at-equal-quality win Thumbro targets elsewhere. This is the honest baseline
-state and the motivation for the planned WebP encoding tuning — see *Accepted trade-offs* and
-*History*. GD never dominates a static cell (it is smaller but enough lower in quality to clear
-the noise tolerance), so the floor holds; GD has no animated path, so it is `UNAVAILABLE` for
-animated WebP and applies no floor there (a default GD-only MediaWiki would drop the animation
-to a static frame entirely — Thumbro preserves it). Numbers from `tests/bench/benchmark.php`.
+**Tally (static): 3 win · 0 loss.** With cwebp at q80, every static cell is **smaller than
+ImageMagick at no-worse quality** and **smaller than the GD floor** (so the floor holds, decisively
+— Thumbro now beats it outright). This is the win the Q90 libvips profile could not reach: libvips
+`webpsave` produced a *larger-but-higher-quality* trade-off, and dropping its Q to win on size
+breached the GD floor (GD's soft downscale compresses unusually small). cwebp threads that needle.
 
-## Accepted trade-offs
+**Animation stays a trade-off.** `anim.webp` goes through libvips (cwebp can't animate): larger
+than ImageMagick (223.8 vs 125.2 KB) but markedly higher quality (84.8 vs 64.3 — *high* vs
+*medium* band). A legitimate quality-for-size exchange under the trade-off principle; improving it
+would need an animation-capable libwebp encoder (`img2webp`), out of scope. Numbers from
+`tests/bench/benchmark.php`.
 
-- **All four representative cells are INCOMPARABLE (larger but higher quality), pending the
-  WebP tuning follow-up.** At Q90 Thumbro re-encodes a WebP source 31–79% larger than
-  ImageMagick while scoring 7–20 SSIMULACRA2 higher (the animation, +20.5, is the widest gap —
-  IM's coalesced WebP bands to *medium* at 64.3 where Thumbro holds *high* at 84.8). Under the
-  trade-off principle this is a legitimate quality-for-size exchange, but inflating an
-  already-compressed source is not the size win Thumbro aims for. **Decision:** record the
-  trade-offs as the current state and carry the profile unchanged into the dedicated WebP
-  tuning (the JPEG precedent — Q90 → Q80 turned 2 win / 4 trade-off / 3 loss into 6 win — is
-  the template; the WebP knee is expected to convert several of these to wins).
+## Decisions
 
-**Performance:** Thumbro is well within the hard caps — static cells peak ~35 MB / < 0.15 s;
-the 44-frame animation ~94 MB / ~0.74 s (animated time ceiling 10 s, RSS 512 MB).
+- **Static WebP → cwebp q80 (2026-06-07).** Swept cwebp q at `-m 6` and compared cwebp@knee vs the
+  vips-webp Q90 profile against the gate. cwebp q80 wins all three static widths (smaller than IM
+  *and* GD); q84+ breaches the GD floor at 250/400px. Chosen.
+- **JPEG and PNG stay vips-webp (cwebp evaluated, not adopted).** See `image-jpeg.md` /
+  `image-png.md`: cwebp ties vips-webp on JPEG (no win) and loses badly on PNG (catastrophic on
+  screenshots/line-art; cannot reach IM quality on the transparent logo even at q90). vips
+  `webpsave` (with `near_lossless` for PNG) stays.
+- **Animation stays vips-webp** — cwebp is single-image only.
+
+**Performance:** within the hard caps. Static cwebp adds a vips-resize→PNG→cwebp two-step (a
+temp PNG + a second process) — generation-time cost, paid once and cached, for a per-view size
+win. The 44-frame animation (libvips) peaks ~94 MB / ~0.74 s (caps: 10 s, 512 MB).
 
 ## History
 
-- **2026-06-06 — gated.** WebP gained a real baseline: ImageMagick (binding) and GD
-  (static-only floor) now apply to `image/webp`, so it gets a dominance verdict like the other
-  MIMEs (ADR-0001 §2). Result on the current Q90 profile: **0 win · 4 trade-off · 0 loss** —
-  larger but higher quality across the board. Profile unchanged this round; the trade-offs set
-  up the dedicated WebP tuning follow-up.
-- **2026-06-06 — measured** (superseded by the row above). Recorded on the redesigned gate
-  with no baseline yet, as the shared WebP/fallback block — tracked, not tuned.
+- **2026-06-07 — static→cwebp q80** (this profile). Added the cwebp encoder and routed static
+  WebP to it: **0 win · 4 trade-off → 3 static win** (+ the animation trade-off unchanged). cwebp
+  is ~2× more byte-efficient than libvips `webpsave`, converting the Q90 trade-offs into wins
+  while clearing the GD floor.
+- **2026-06-06 — gated, Q90 libvips** (superseded). WebP gained a baseline (IM binding, GD
+  static-only floor; ADR-0001 §2); the Q90 libvips profile scored 0 win / 4 trade-off (larger but
+  higher quality). That trade-off motivated the cwebp work above.
+- **2026-06-06 — measured** (superseded). Recorded on the redesigned gate with no baseline yet.
 
 ## Reproduce
 
-`php tests/bench/benchmark.php --mime=image/webp` (see `tests/bench/README.md`).
+`php tests/bench/benchmark.php --mime=image/webp` (see `tests/bench/README.md`). cwebp parameter
+exploration: `php tests/bench/bin/sweep-cwebp.php`.

--- a/extension.json
+++ b/extension.json
@@ -100,6 +100,9 @@
 				},
 				"libwebp": {
 					"command": "/usr/bin/gif2webp"
+				},
+				"cwebp": {
+					"command": "/usr/bin/cwebp"
 				}
 			}
 		},
@@ -152,6 +155,15 @@
 					"enabled": true,
 					"resize": { "options": {} },
 					"encode": [
+						{
+							"encoder": "vips-webp",
+							"when": { "animated": true },
+							"options": { "strip": "true", "Q": "90", "smart_subsample": "true" }
+						},
+						{
+							"encoder": "cwebp",
+							"options": { "q": "80", "m": "6" }
+						},
 						{
 							"encoder": "vips-webp",
 							"options": { "strip": "true", "Q": "90", "smart_subsample": "true" }

--- a/includes/Backend/Encoder/CwebpEncoder.php
+++ b/includes/Backend/Encoder/CwebpEncoder.php
@@ -7,12 +7,11 @@ use MediaWiki\Extension\Thumbro\Shell\ShellCommand;
 use MediaWiki\Extension\Thumbro\Shell\ShellCommandFactory;
 
 /**
- * gif2webp (libwebp) encoder. Two-step: consumes the output of a prior vips resize (a GIF
- * intermediate) and encodes WebP — used for animation by the routing (`when: animated`), though
- * the tool itself handles static GIFs too. Mirrors the former LibwebpBackend::planLibwebpEncode
- * encode half byte-for-byte.
+ * cwebp (libwebp) encoder. Two-step, static only: consumes a vips-resized PNG intermediate and
+ * encodes a single WebP. libwebp's cwebp is markedly more byte-efficient than vips webpsave on
+ * some content; per-MIME routing (vips-webp vs cwebp) is decided by the benchmark gate.
  */
-class Gif2webpEncoder implements Encoder {
+class CwebpEncoder implements Encoder {
 
 	public function __construct(
 		private readonly string $command,
@@ -20,16 +19,15 @@ class Gif2webpEncoder implements Encoder {
 	}
 
 	public function name(): string {
-		return 'gif2webp';
+		return 'cwebp';
 	}
 
-	/** Available only when the gif2webp binary is configured and executable (old libwebpAvailable). */
 	public function isAvailable(): bool {
 		return $this->command !== '' && is_executable( $this->command );
 	}
 
 	public function supportsAnimation(): bool {
-		return true;
+		return false;
 	}
 
 	public function supportsAlpha(): bool {
@@ -41,7 +39,7 @@ class Gif2webpEncoder implements Encoder {
 	}
 
 	public function intermediateFormat(): ?string {
-		return 'gif';
+		return 'png';
 	}
 
 	public function planEncode(

--- a/includes/Backend/Encoder/EncodeInput.php
+++ b/includes/Backend/Encoder/EncodeInput.php
@@ -7,7 +7,7 @@ use MediaWiki\Extension\Thumbro\Shell\ShellCommand;
 
 /**
  * Input to an {@see Encoder}. A fused encoder (vips) encodes from the source at a target size with
- * load options; a two-step encoder (gif2webp, later cwebp) encodes from the output of a prior
+ * load options; a two-step encoder (gif2webp, cwebp) encodes from the output of a prior
  * resize command.
  */
 class EncodeInput {

--- a/includes/Backend/Encoder/Encoder.php
+++ b/includes/Backend/Encoder/Encoder.php
@@ -11,7 +11,7 @@ use MediaWiki\Extension\Thumbro\Shell\ShellCommandFactory;
  * routing and the resize/encode wiring are explicit, not hidden in the coordinator.
  *
  * `requiresResizedInput()` is the explicit fused-vs-two-step flag: vips-webp resizes and encodes
- * in one command (false); external tools (gif2webp, later cwebp) consume a vips-produced
+ * in one command (false); external tools (gif2webp, cwebp) consume a vips-produced
  * intermediate (true), whose format `intermediateFormat()` names.
  */
 interface Encoder {

--- a/includes/Backend/Resize/Resizer.php
+++ b/includes/Backend/Resize/Resizer.php
@@ -8,7 +8,7 @@ use MediaWiki\Extension\Thumbro\Shell\ShellCommandFactory;
 
 /**
  * Resizes a source image to an intermediate file at the target physical size, for two-step
- * encoders (gif2webp, later cwebp) that cannot resize themselves. One implementation today
+ * encoders (gif2webp, cwebp) that cannot resize themselves. One implementation today
  * ({@see VipsResizer}); this seam lets a second resize engine slot in later without touching
  * the encoders.
  */

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Thumbro;
 
 use MediaWiki\Extension\Thumbro\Backend\CommandPlanRunner;
 use MediaWiki\Extension\Thumbro\Backend\EncodePipeline;
+use MediaWiki\Extension\Thumbro\Backend\Encoder\CwebpEncoder;
 use MediaWiki\Extension\Thumbro\Backend\Encoder\EncoderRouter;
 use MediaWiki\Extension\Thumbro\Backend\Encoder\Gif2webpEncoder;
 use MediaWiki\Extension\Thumbro\Backend\Encoder\VipsWebpEncoder;
@@ -46,13 +47,14 @@ return [
 
 	/**
 	 * The available encoders, keyed by the name used in a MIME's `encode` list. Each carries its
-	 * own binary; the resizer + vips-webp share the libvips binary, gif2webp the libwebp one.
+	 * own binary: vips-webp uses libvips; gif2webp and cwebp are the two libwebp tools.
 	 */
 	'Thumbro.Encoders' => static function ( MediaWikiServices $services ): array {
 		$libraries = $services->getConfigFactory()->makeConfig( 'thumbro' )->get( 'ThumbroLibraries' );
 		return [
 			'vips-webp' => new VipsWebpEncoder( $libraries['libvips']['command'] ?? '' ),
 			'gif2webp' => new Gif2webpEncoder( $libraries['libwebp']['command'] ?? '' ),
+			'cwebp' => new CwebpEncoder( $libraries['cwebp']['command'] ?? '' ),
 		];
 	},
 

--- a/includes/Shell/ShellCommand.php
+++ b/includes/Shell/ShellCommand.php
@@ -31,7 +31,7 @@ class ShellCommand {
 	 * @param string $name Human-readable backend label for debug logging.
 	 * @param string $command Binary to run.
 	 * @param array<string,string> $args Flags for the command.
-	 * @param string $style Argument flattening style: 'vips' or 'gif2webp'.
+	 * @param string $style Argument flattening style: 'vips' or 'libwebp'.
 	 */
 	public function __construct(
 		private readonly TempFSFileFactory $tempFactory,
@@ -84,7 +84,7 @@ class ShellCommand {
 	/** Flatten arguments according to the command's argument style. */
 	private function makeArguments( array $args ): array {
 		$cmdArgs = [];
-		if ( $this->style === 'gif2webp' ) {
+		if ( $this->style === 'libwebp' ) {
 			// Single-dash flags; valued flags render as two tokens "-flag value".
 			foreach ( $args as $key => $value ) {
 				$cmdArgs[] = "-$key";
@@ -107,8 +107,8 @@ class ShellCommand {
 
 	/** Constructs the command line array for executing the command. */
 	private function buildCommand(): array {
-		if ( $this->style === 'gif2webp' ) {
-			// gif2webp: <command> <flags...> <input> -o <output>
+		if ( $this->style === 'libwebp' ) {
+			// libwebp style (gif2webp, cwebp): <command> <flags...> <input> -o <output>
 			$cmd = array_merge( [ $this->command ], $this->makeArguments( $this->args ) );
 			$cmd[] = $this->input;
 			$cmd[] = '-o';

--- a/includes/Shell/ShellCommandFactory.php
+++ b/includes/Shell/ShellCommandFactory.php
@@ -20,7 +20,7 @@ class ShellCommandFactory {
 	 * @param string $name Human-readable backend label for debug logging.
 	 * @param string $command Binary to run.
 	 * @param array<string,string> $args Flags for the command.
-	 * @param string $style Argument flattening style: 'vips' or 'gif2webp'.
+	 * @param string $style Argument flattening style: 'vips' or 'libwebp'.
 	 */
 	public function create( string $name, string $command, array $args, string $style = 'vips' ): ShellCommand {
 		return new ShellCommand( $this->tempFactory, $name, $command, $args, $style );

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -20,6 +20,8 @@ bash tests/bench/bin/install-ssimulacra2.sh   # SSIMULACRA2 metric (needs root +
 - `convert` (imagemagick), `vips`/`vipsthumbnail` (libvips-tools): thumbnailing,
   reference downscale, and animated-frame extraction (`anim_dump` is NOT packaged, so
   animated-WebP frames are extracted with `convert -coalesce`).
+- `cwebp` (the `webp` package, libwebp): the static-WebP production encoder (`sweep-cwebp.php`
+  and the gate's Thumbro contender shell out to it). `gif2webp` ships in the same package.
 - `time` (GNU time): peak-RSS capture.
 
 ## Run

--- a/tests/bench/bin/sweep-cwebp.php
+++ b/tests/bench/bin/sweep-cwebp.php
@@ -1,0 +1,200 @@
+<?php
+declare( strict_types=1 );
+
+/**
+ * cwebp parameter sweep (research tool, NOT the acceptance gate).
+ *
+ * For each static raster representative fixture, resizes with vipsthumbnail to a
+ * lossless PNG intermediate, then encodes with cwebp -q <Q> -m 6, scores every cell
+ * with SSIMULACRA2 against the same lossless vips reference the gate uses, and prints a
+ * size-vs-quality table so the knee can be read off by eye.
+ *
+ * cwebp cannot resize or animate, so only static raster representative fixtures are
+ * swept. Produces NO verdict: selection is a human decision recorded in docs/encoding/.
+ *
+ * Encoding pipeline per cell:
+ *   1. vipsthumbnail <src> --size <w>x100000 -o <tmp>.png   (lossless, carries alpha)
+ *   2. cwebp -q <Q> -m 6 <tmp>.png -o <out>.webp
+ *
+ * Reuses the gate's scoring plumbing (Reference, Ssimulacra2, ImageDims, Subprocess,
+ * ToolLocator) so a sweep score means exactly what a gate score means.
+ *
+ * Usage: php tests/bench/bin/sweep-cwebp.php [--out=DIR]
+ */
+
+// Standalone autoloader, identical to benchmark.php (no MediaWiki bootstrap).
+spl_autoload_register( static function ( string $class ): void {
+	$prefix = 'MediaWiki\\Extension\\Thumbro\\Bench\\';
+	if ( !str_starts_with( $class, $prefix ) ) {
+		return;
+	}
+	$parts = explode( '\\', substr( $class, strlen( $prefix ) ) );
+	$last = array_pop( $parts );
+	$rel = ( $parts ? implode( '/', $parts ) . '/' : '' ) . $last;
+	$file = __DIR__ . '/../src/' . $rel . '.php';
+	if ( is_file( $file ) ) {
+		require $file;
+	}
+} );
+
+use MediaWiki\Extension\Thumbro\Bench\ImageDims;
+use MediaWiki\Extension\Thumbro\Bench\Reference;
+use MediaWiki\Extension\Thumbro\Bench\Ssimulacra2;
+use MediaWiki\Extension\Thumbro\Bench\Subprocess;
+use MediaWiki\Extension\Thumbro\Bench\ToolLocator;
+
+$opts = getopt( '', [ 'out::', 'help' ] );
+if ( isset( $opts['help'] ) ) {
+	fwrite( STDOUT, "Usage: php tests/bench/bin/sweep-cwebp.php [--out=DIR]\n" );
+	exit( 0 );
+}
+$outDir = is_string( $opts['out'] ?? null ) ? $opts['out'] : ( getcwd() . '/sweep-out' );
+if ( !is_dir( $outDir ) && !mkdir( $outDir, 0777, true ) && !is_dir( $outDir ) ) {
+	fwrite( STDERR, "Cannot create out dir: $outDir\n" );
+	exit( 1 );
+}
+
+$corpusDir = __DIR__ . '/../corpus';
+
+/**
+ * Static raster representative fixtures. cwebp cannot animate, so only static fixtures
+ * are included. photo.webp is included as a cross-format data point (cwebp re-encoding
+ * a lossy WebP source via lossless-PNG intermediate).
+ */
+$fixtures = [
+	[ 'file' => 'photo.jpg', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'portrait.jpg', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'concept-art.jpg', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'logo-transparent.png', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'flat-graphic.png', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'screenshot-ui.png', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'screenshot-gaming.png', 'widths' => [ 180, 250, 400 ] ],
+	[ 'file' => 'photo.webp', 'widths' => [ 180, 250, 400 ] ],
+];
+
+/**
+ * Quality grid. Method (-m) is fixed at 6 (max encoder effort, "free" per the
+ * cached-generation trade-off principle). Q values match the vips sweep grid so
+ * cwebp and vips-webp results are directly comparable.
+ */
+$qValues = [ 60, 70, 75, 80, 84, 90 ];
+
+$vips = ToolLocator::require( 'vipsthumbnail', 'libvips-tools' );
+$cwebp = ToolLocator::require( 'cwebp', 'libwebp (webp package)' );
+// Fail fast on the metric so we don't encode many thumbs then discover it's missing.
+ToolLocator::require( Ssimulacra2::$bin, 'tests/bench/bin/install-ssimulacra2.sh' );
+
+$rows = [];
+$total = 0;
+foreach ( $fixtures as $fx ) {
+	$total += count( $fx['widths'] ) * count( $qValues );
+}
+$done = 0;
+
+foreach ( $fixtures as $fx ) {
+	$src = $corpusDir . '/' . $fx['file'];
+	if ( !is_file( $src ) ) {
+		fwrite( STDERR, "Missing fixture: $src\n" );
+		continue;
+	}
+	// Slug includes the extension so fixtures that share a basename (photo.jpg / photo.webp)
+	// don't collide on the same intermediate/cell directory and reuse each other's pixels.
+	$slug = str_replace( '.', '_', $fx['file'] );
+	foreach ( $fx['widths'] as $w ) {
+		// Shared PNG intermediate for all Q values at this (fixture, width).
+		$interDir = sprintf( '%s/%s_%d', $outDir, $slug, $w );
+		if ( !is_dir( $interDir ) && !mkdir( $interDir, 0777, true ) && !is_dir( $interDir ) ) {
+			fwrite( STDERR, "Cannot create $interDir\n" );
+			continue;
+		}
+		$pngPath = $interDir . '/resized.png';
+
+		// Step 1: resize to PNG (done once per (fixture, width); reused across all Q values).
+		if ( !is_file( $pngPath ) ) {
+			$resizeProc = Subprocess::run( [
+				$vips, $src, '--size', $w . 'x100000', '-o', $pngPath . '[strip=true]',
+			] );
+			if ( !$resizeProc->ok() || !is_file( $pngPath ) ) {
+				fwrite( STDERR, "  vips resize FAILED $fx[file]@$w: $resizeProc->stderr\n" );
+				continue;
+			}
+		}
+
+		foreach ( $qValues as $q ) {
+			$label = 'Q=' . $q . ',m=6';
+			$done++;
+			$cellDir = sprintf( '%s/%s_%d/%s', $outDir, $slug, $w, $label );
+			if ( !is_dir( $cellDir ) && !mkdir( $cellDir, 0777, true ) && !is_dir( $cellDir ) ) {
+				fwrite( STDERR, "Cannot create $cellDir\n" );
+				continue;
+			}
+			$dst = $cellDir . '/thumb.webp';
+
+			// Step 2: encode with cwebp.
+			$encProc = Subprocess::run( [ $cwebp, '-q', (string)$q, '-m', '6', $pngPath, '-o', $dst ] );
+			if ( !$encProc->ok() || !is_file( $dst ) ) {
+				fwrite( STDERR, "  [$done/$total] cwebp FAILED $fx[file]@$w $label: $encProc->stderr\n" );
+				continue;
+			}
+			$bytes = (int)filesize( $dst );
+
+			// Score exactly as the gate does: lossless vips reference at the produced dims,
+			// candidate extracted to full-canvas PNG, SSIMULACRA2 over the pair.
+			[ $tw, $th ] = ImageDims::of( $dst );
+			$refDir = $cellDir . '/ref';
+			$candDir = $cellDir . '/cand';
+			foreach ( [ $refDir, $candDir ] as $d ) {
+				if ( !is_dir( $d ) ) {
+					mkdir( $d, 0777, true );
+				}
+			}
+			$score = null;
+			try {
+				$ref = Reference::forStatic( $src, $tw, $th, $refDir );
+				$cand = Ssimulacra2::extractFrames( $dst, 1, $candDir );
+				$score = Ssimulacra2::score( [ $ref ], $cand )->mean;
+			} catch ( \RuntimeException $e ) {
+				fwrite( STDERR, "  scoring failed $fx[file]@$w $label: {$e->getMessage()}\n" );
+			}
+
+			$rows[] = [
+				'fixture' => $fx['file'],
+				'width' => $w,
+				'config' => $label,
+				'bytes' => $bytes,
+				'ssimulacra2' => $score !== null ? round( $score, 2 ) : null,
+				'wall_ms' => round( $encProc->wallMs, 1 ),
+				'peak_rss_kb' => $encProc->peakRssKb,
+			];
+			fwrite( STDOUT, sprintf(
+				"[%d/%d] %-18s @%-4d %-14s  %8d B  s2=%-6s  %6.0fms\n",
+				$done, $total, $fx['file'], $w, $label, $bytes,
+				$score !== null ? number_format( $score, 2 ) : 'n/a', $encProc->wallMs
+			) );
+		}
+	}
+}
+
+file_put_contents( $outDir . '/sweep-results.json', json_encode( $rows, JSON_PRETTY_PRINT ) . "\n" );
+
+// Per (fixture,width) table sorted by size ascending — the knee is read top-to-bottom.
+$groups = [];
+foreach ( $rows as $r ) {
+	$groups[$r['fixture'] . ' @' . $r['width'] . 'px'][] = $r;
+}
+fwrite( STDOUT, "\n================ SIZE-SORTED (knee read top-down) ================\n" );
+foreach ( $groups as $title => $grp ) {
+	usort( $grp, static fn ( $a, $b ) => $a['bytes'] <=> $b['bytes'] );
+	fwrite( STDOUT, "\n## $title\n" );
+	fwrite( STDOUT, sprintf( "  %-14s %9s %8s %9s %10s\n", 'config', 'bytes', 's2', 'wall_ms', 'rss_kb' ) );
+	foreach ( $grp as $r ) {
+		fwrite( STDOUT, sprintf(
+			"  %-14s %9d %8s %9s %10s\n",
+			$r['config'], $r['bytes'],
+			$r['ssimulacra2'] !== null ? number_format( $r['ssimulacra2'], 2 ) : 'n/a',
+			number_format( $r['wall_ms'], 0 ),
+			$r['peak_rss_kb'] !== null ? number_format( $r['peak_rss_kb'] ) : 'n/a'
+		) );
+	}
+}
+fwrite( STDOUT, "\nWrote {$outDir}/sweep-results.json\n" );

--- a/tests/bench/src/Contenders/ThumbroGif.php
+++ b/tests/bench/src/Contenders/ThumbroGif.php
@@ -142,7 +142,7 @@ class ThumbroGif implements Contender {
 	}
 
 	/**
-	 * Render gif2webp flags as argv tokens, matching ShellCommand's 'gif2webp' style: each flag
+	 * Render gif2webp flags as argv tokens, matching ShellCommand's 'libwebp' style: each flag
 	 * is "-key", with a following value token only when the flag carries one ("" means bare).
 	 *
 	 * @param array<string,string> $flags

--- a/tests/bench/src/Contenders/ThumbroVips.php
+++ b/tests/bench/src/Contenders/ThumbroVips.php
@@ -9,7 +9,8 @@ use MediaWiki\Extension\Thumbro\Bench\Subprocess;
 use MediaWiki\Extension\Thumbro\Bench\ToolLocator;
 
 /**
- * Reproduces Thumbro's vipsthumbnail path.
+ * Reproduces Thumbro's vipsthumbnail path, and the two-step vips-resize→cwebp path for MIMEs
+ * whose static encoder resolves to `cwebp` (currently image/webp).
  *
  * The load/save option suffixes are derived from extension.json (config.ThumbroOptions.value)
  * rather than hand-copied, so the contender cannot silently drift from production — earlier
@@ -19,6 +20,10 @@ use MediaWiki\Extension\Thumbro\Bench\ToolLocator;
  * webpsave options come from that block's `vips-webp` encode entry, falling back to the image/webp
  * block's `vips-webp` entry (so jpeg/webp share the webp save options while image/png carries its
  * own near-lossless entry).
+ *
+ * {@see self::staticEncoderFor()} mirrors EncoderRouter::choose with animated=false: it returns
+ * the first encode-list entry whose `when` guard does not require `animated:true` (a missing `when`
+ * is the catch-all). For image/webp this is now `cwebp`; for jpeg/png it is `vips-webp`.
  *
  * GIF is handled by {@see ThumbroGif} instead — its options are a runtime encode-list routing
  * decision (gif2webp, or vips-webp with forced n), not a single-entry config lookup.
@@ -40,12 +45,26 @@ class ThumbroVips implements Contender {
 	}
 
 	public function run( string $srcPath, string $mime, int $targetWidth, string $destDir ): Result {
-		$bin = ToolLocator::path( 'vipsthumbnail' );
-		if ( $bin === null ) {
+		$vips = ToolLocator::path( 'vipsthumbnail' );
+		if ( $vips === null ) {
 			return Result::unavailable( $this->name(), $srcPath, $targetWidth, 'vipsthumbnail not found' );
 		}
 		$dst = $destDir . '/thumbro_' . $targetWidth . '.webp';
-		[ $inSuffix, $outSuffix ] = self::optionsFor( $mime, self::thumbroOptions() );
+		$options = self::thumbroOptions();
+		$staticEncoder = self::staticEncoderFor( $mime, $options );
+		$cwebpBin = ToolLocator::path( 'cwebp' );
+
+		// Two-step path: vips resize to PNG intermediate, then cwebp encode.
+		// Only for static (non-animated) sources — cwebp cannot animate, so animated WebP is
+		// always handled by the fused vips path below regardless of the static encoder.
+		// Falls back to vips path when cwebp binary is absent (mirrors the production
+		// vips-webp catch-all that degrades gracefully when cwebp is unavailable).
+		if ( $staticEncoder === 'cwebp' && $cwebpBin !== null && !self::isAnimated( $srcPath ) ) {
+			return $this->runCwebp( $vips, $cwebpBin, $srcPath, $mime, $targetWidth, $destDir, $dst, $options );
+		}
+
+		// Fused vips path (vips-webp encoder): single vipsthumbnail call with webpsave options.
+		[ $inSuffix, $outSuffix ] = self::optionsFor( $mime, $options );
 		// Animated WebP: production forces n=-1 (the pipeline prepends it for an animation-capable
 		// encoder on an animated, under-threshold source) so the thumbnail keeps every frame
 		// instead of flattening to the first. Mirror it so the bench measures what production
@@ -56,7 +75,7 @@ class ThumbroVips implements Contender {
 		$in = $srcPath . $inSuffix;
 		$out = $dst . $outSuffix;
 		// Height bound large so width governs (matches MediaWiki width-based thumbs).
-		$cmd = [ $bin, $in, '--size', $targetWidth . 'x100000', '-o', $out ];
+		$cmd = [ $vips, $in, '--size', $targetWidth . 'x100000', '-o', $out ];
 
 		$proc = Subprocess::run( $cmd );
 		if ( !$proc->ok() || !is_file( $dst ) ) {
@@ -69,10 +88,79 @@ class ThumbroVips implements Contender {
 	}
 
 	/**
+	 * Two-step encode: vipsthumbnail to a PNG intermediate, then cwebp to the final WebP.
+	 *
+	 * @param string $vips Path to vipsthumbnail binary
+	 * @param string $cwebpBin Path to cwebp binary
+	 * @param string $srcPath Source image path
+	 * @param string $mime Input MIME type
+	 * @param int $targetWidth Target thumbnail width
+	 * @param string $destDir Destination directory
+	 * @param string $dst Final WebP destination path
+	 * @param array<string,array<string,mixed>> $thumbroOptions ThumbroOptions config
+	 */
+	private function runCwebp(
+		string $vips,
+		string $cwebpBin,
+		string $srcPath,
+		string $mime,
+		int $targetWidth,
+		string $destDir,
+		string $dst,
+		array $thumbroOptions
+	): Result {
+		$tmp = $destDir . '/thumbro_' . $targetWidth . '_tmp.png';
+		[ $inSuffix, ] = self::optionsFor( $mime, $thumbroOptions );
+		$in = $srcPath . $inSuffix;
+		// Step 1: vips resize to PNG intermediate (no webpsave suffix).
+		$resizeCmd = [ $vips, $in, '--size', $targetWidth . 'x100000', '-o', $tmp ];
+		$resizeProc = Subprocess::run( $resizeCmd );
+		if ( !$resizeProc->ok() || !is_file( $tmp ) ) {
+			return Result::unavailable(
+				$this->name(), $srcPath, $targetWidth,
+				'vips resize step failed: ' . $resizeProc->stderr
+			);
+		}
+
+		// Step 2: cwebp encode the PNG intermediate to the destination WebP.
+		$cwebpOptions = self::cwebpOptionsFor( $mime, $thumbroOptions );
+		$cwebpCmd = [ $cwebpBin ];
+		foreach ( $cwebpOptions as $key => $value ) {
+			$cwebpCmd[] = '-' . $key;
+			if ( $value !== '' ) {
+				$cwebpCmd[] = $value;
+			}
+		}
+		$cwebpCmd[] = $tmp;
+		$cwebpCmd[] = '-o';
+		$cwebpCmd[] = $dst;
+		$encodeProc = Subprocess::run( $cwebpCmd );
+		// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		@unlink( $tmp );
+		if ( !$encodeProc->ok() || !is_file( $dst ) ) {
+			return Result::unavailable(
+				$this->name(), $srcPath, $targetWidth,
+				'cwebp encode step failed: ' . $encodeProc->stderr
+			);
+		}
+		// Aggregate wall time and take the larger of the two peak RSS readings.
+		$wallMs = $resizeProc->wallMs + $encodeProc->wallMs;
+		$peakRss = max( $resizeProc->peakRssKb ?? 0, $encodeProc->peakRssKb ?? 0 );
+		return new Result(
+			$this->name(), $srcPath, $targetWidth, $dst,
+			filesize( $dst ), $wallMs, $peakRss === 0 ? null : $peakRss, true
+		);
+	}
+
+	/**
 	 * The vipsthumbnail "[..]" load/save suffixes Thumbro runs for $mime, derived from the given
 	 * ThumbroOptions config. Mirrors the production resize→encode path: load options from the
 	 * input-MIME block's `resize.options`; webpsave options from that block's `vips-webp` encode
 	 * entry, else the image/webp block's `vips-webp` entry.
+	 *
+	 * For MIMEs routed to cwebp (e.g. static image/webp), this still returns the input suffix
+	 * (from resize.options) and an empty output suffix — the caller uses the input suffix for the
+	 * vips resize step and ignores the output suffix (cwebp handles encoding separately).
 	 *
 	 * @param string $mime input MIME type
 	 * @param array<string,array<string,mixed>> $thumbroOptions config.ThumbroOptions.value
@@ -84,6 +172,42 @@ class ThumbroVips implements Contender {
 			?? self::vipsWebpOptions( $thumbroOptions['image/webp'] ?? [] )
 			?? [];
 		return [ self::makeOptions( $input ), self::makeOptions( $output ) ];
+	}
+
+	/**
+	 * The encoder name for a static (non-animated) source of the given MIME. Mirrors
+	 * EncoderRouter::choose with animated=false: returns the first encode-list entry whose `when`
+	 * guard does not require `animated:true` (a missing `when` is the catch-all).
+	 *
+	 * @param string $mime input MIME type
+	 * @param array<string,array<string,mixed>> $thumbroOptions config.ThumbroOptions.value
+	 */
+	public static function staticEncoderFor( string $mime, array $thumbroOptions ): string {
+		foreach ( $thumbroOptions[$mime]['encode'] ?? [] as $entry ) {
+			$when = $entry['when'] ?? [];
+			// Skip entries that require animated=true (they only apply to animations).
+			if ( ( $when['animated'] ?? null ) === true ) {
+				continue;
+			}
+			return $entry['encoder'] ?? 'vips-webp';
+		}
+		return 'vips-webp';
+	}
+
+	/**
+	 * The `options` array from the first `cwebp` encode entry in the given MIME block.
+	 *
+	 * @param string $mime input MIME type
+	 * @param array<string,array<string,mixed>> $thumbroOptions config.ThumbroOptions.value
+	 * @return array<string,string>
+	 */
+	public static function cwebpOptionsFor( string $mime, array $thumbroOptions ): array {
+		foreach ( $thumbroOptions[$mime]['encode'] ?? [] as $entry ) {
+			if ( ( $entry['encoder'] ?? '' ) === 'cwebp' ) {
+				return $entry['options'] ?? [];
+			}
+		}
+		return [];
 	}
 
 	/**

--- a/tests/phpunit/unit/Backend/CommandPlanTest.php
+++ b/tests/phpunit/unit/Backend/CommandPlanTest.php
@@ -22,7 +22,7 @@ class CommandPlanTest extends MediaWikiUnitTestCase {
 	public function testOfKeepsCommandsInOrder(): void {
 		$factory = $this->createMock( TempFSFileFactory::class );
 		$a = new ShellCommand( $factory, 'libvips', '/bin/a', [] );
-		$b = new ShellCommand( $factory, 'libwebp', '/bin/b', [], 'gif2webp' );
+		$b = new ShellCommand( $factory, 'libwebp', '/bin/b', [], 'libwebp' );
 		$plan = CommandPlan::of( $a, $b );
 
 		$this->assertFalse( $plan->isEmpty() );

--- a/tests/phpunit/unit/Backend/Encoder/CwebpEncoderTest.php
+++ b/tests/phpunit/unit/Backend/Encoder/CwebpEncoderTest.php
@@ -1,0 +1,52 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Unit\Backend\Encoder;
+
+use MediaWiki\Extension\Thumbro\Backend\Encoder\CwebpEncoder;
+use MediaWiki\Extension\Thumbro\Backend\Encoder\EncodeInput;
+use MediaWiki\Extension\Thumbro\Shell\ShellCommand;
+use MediaWiki\Extension\Thumbro\Shell\ShellCommandFactory;
+use MediaWiki\FileBackend\FSFile\TempFSFileFactory;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Thumbro\Backend\Encoder\CwebpEncoder
+ */
+class CwebpEncoderTest extends MediaWikiUnitTestCase {
+
+	private function factory(): ShellCommandFactory {
+		return new ShellCommandFactory( new TempFSFileFactory() );
+	}
+
+	public function testCapabilities(): void {
+		$enc = new CwebpEncoder( '/usr/bin/cwebp' );
+		$this->assertSame( 'cwebp', $enc->name() );
+		$this->assertTrue( $enc->requiresResizedInput() );
+		$this->assertSame( 'png', $enc->intermediateFormat() );
+		$this->assertFalse( $enc->supportsAnimation() );
+		$this->assertTrue( $enc->supportsAlpha() );
+	}
+
+	public function testIsAvailable(): void {
+		$this->assertTrue( ( new CwebpEncoder( '/bin/sh' ) )->isAvailable() );
+		$this->assertFalse( ( new CwebpEncoder( '/no/such/cwebp' ) )->isAvailable() );
+		$this->assertFalse( ( new CwebpEncoder( '' ) )->isAvailable() );
+	}
+
+	public function testPlanEncodeBuildsCwebpArgv(): void {
+		$factory = $this->factory();
+		$resize = $factory->create( 'libvips', '/usr/bin/vipsthumbnail', [ 'size' => '250x100000' ] );
+		$resize->setIO( '/src.png', 'png', ShellCommand::TEMP_OUTPUT );
+
+		$enc = new CwebpEncoder( '/usr/bin/cwebp' );
+		$cmd = $enc->planEncode(
+			$factory, EncodeInput::fromResized( $resize ), '/dst.webp', [ 'q' => '80', 'm' => '6' ]
+		);
+		$argv = $cmd->buildCommandForTest();
+		$this->assertSame( '/usr/bin/cwebp', $argv[0] );
+		$this->assertSame( [ '-q', '80', '-m', '6' ], array_slice( $argv, 1, 4 ) );
+		$this->assertSame( $resize->getOutput(), $argv[5] );
+		$this->assertSame( [ '-o', '/dst.webp' ], array_slice( $argv, 6 ) );
+	}
+}

--- a/tests/phpunit/unit/Bench/ThumbroVipsTest.php
+++ b/tests/phpunit/unit/Bench/ThumbroVipsTest.php
@@ -10,7 +10,11 @@ use MediaWikiUnitTestCase;
  * @covers \MediaWiki\Extension\Thumbro\Bench\Contenders\ThumbroVips
  */
 class ThumbroVipsTest extends MediaWikiUnitTestCase {
-	/** A synthetic ThumbroOptions config (new per-MIME resize + encode schema). */
+	/**
+	 * A synthetic ThumbroOptions config (new per-MIME resize + encode schema).
+	 * The image/webp block mirrors production: animated → vips-webp; static → cwebp (q80,m6);
+	 * vips-webp catch-all for a missing cwebp binary.
+	 */
 	private const CONFIG = [
 		'image/jpeg' => [
 			'resize' => [ 'options' => [] ],
@@ -22,7 +26,21 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 		],
 		'image/webp' => [
 			'resize' => [ 'options' => [] ],
-			'encode' => [ [ 'encoder' => 'vips-webp', 'options' => [ 'strip' => 'true', 'Q' => '90' ] ] ],
+			'encode' => [
+				[
+					'encoder' => 'vips-webp',
+					'when' => [ 'animated' => true ],
+					'options' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ],
+				],
+				[
+					'encoder' => 'cwebp',
+					'options' => [ 'q' => '80', 'm' => '6' ],
+				],
+				[
+					'encoder' => 'vips-webp',
+					'options' => [ 'strip' => 'true', 'Q' => '90', 'smart_subsample' => 'true' ],
+				],
+			],
 		],
 	];
 
@@ -38,9 +56,11 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 		$this->assertSame( '[strip=true,Q=80]', $out );
 	}
 
-	public function testWebpUsesItsOwnVipsWebpEntry(): void {
+	public function testWebpVipsWebpOptionsFromAnimatedEntry(): void {
+		// optionsFor returns the first vips-webp entry's options (the animated guard entry).
+		// These options are used for the vips animated-webp path; static webp uses cwebp instead.
 		[ , $out ] = ThumbroVips::optionsFor( 'image/webp', self::CONFIG );
-		$this->assertSame( '[strip=true,Q=90]', $out );
+		$this->assertSame( '[strip=true,Q=90,smart_subsample=true]', $out );
 	}
 
 	public function testFallsBackToWebpEntryWhenBlockHasNoVipsWebp(): void {
@@ -48,13 +68,46 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 		$config = self::CONFIG;
 		$config['image/jpeg']['encode'] = [ [ 'encoder' => 'gif2webp', 'options' => [ 'q' => '80' ] ] ];
 		[ , $out ] = ThumbroVips::optionsFor( 'image/jpeg', $config );
-		$this->assertSame( '[strip=true,Q=90]', $out, 'fell back to the webp block vips-webp options' );
+		$this->assertSame(
+			'[strip=true,Q=90,smart_subsample=true]', $out, 'fell back to the webp block vips-webp options'
+		);
 	}
 
 	public function testOptionsRenderInConfigInsertionOrder(): void {
 		// Same rule as VipsOptionSuffix::make — keys are emitted in config order.
 		[ , $out ] = ThumbroVips::optionsFor( 'image/png', self::CONFIG );
 		$this->assertSame( '[near_lossless=true,Q=60]', $out );
+	}
+
+	// --- staticEncoderFor ---
+
+	public function testStaticEncoderForWebpIsCwebp(): void {
+		// Static image/webp → cwebp (the first encode entry without animated:true guard).
+		$encoder = ThumbroVips::staticEncoderFor( 'image/webp', self::CONFIG );
+		$this->assertSame( 'cwebp', $encoder );
+	}
+
+	public function testStaticEncoderForJpegIsVipsWebp(): void {
+		$encoder = ThumbroVips::staticEncoderFor( 'image/jpeg', self::CONFIG );
+		$this->assertSame( 'vips-webp', $encoder );
+	}
+
+	public function testStaticEncoderForPngIsVipsWebp(): void {
+		$encoder = ThumbroVips::staticEncoderFor( 'image/png', self::CONFIG );
+		$this->assertSame( 'vips-webp', $encoder );
+	}
+
+	// --- cwebpOptionsFor ---
+
+	public function testCwebpOptionsForWebp(): void {
+		$opts = ThumbroVips::cwebpOptionsFor( 'image/webp', self::CONFIG );
+		$this->assertSame( [ 'q' => '80', 'm' => '6' ], $opts );
+	}
+
+	public function testCwebpOptionsForJpegReturnsEmpty(): void {
+		// jpeg has no cwebp entry.
+		$opts = ThumbroVips::cwebpOptionsFor( 'image/jpeg', self::CONFIG );
+		$this->assertSame( [], $opts );
 	}
 
 	/**
@@ -79,8 +132,12 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 		$this->assertNotSame( $webp, $jpeg, 'jpeg carries its own vips-webp entry, not the webp fallback' );
 	}
 
-	/** The exact production suffixes for jpeg/png/webp must be unchanged by the schema migration. */
-	public function testProducesUnchangedProductionSuffixes(): void {
+	/**
+	 * Exact production suffixes for jpeg and png must be unchanged. For webp, optionsFor returns
+	 * the animated vips-webp entry's options (the first vips-webp in the encode list); the static
+	 * path is now cwebp, tested separately via staticEncoderFor/cwebpOptionsFor.
+	 */
+	public function testProducesProductionSuffixes(): void {
 		$config = json_decode(
 			(string)file_get_contents( __DIR__ . '/../../../../extension.json' ), true
 		)['config']['ThumbroOptions']['value'];
@@ -93,9 +150,35 @@ class ThumbroVipsTest extends MediaWikiUnitTestCase {
 			[ '', '[near_lossless=true,Q=60,strip=true]' ],
 			ThumbroVips::optionsFor( 'image/png', $config )
 		);
+		// The vips-webp suffix for webp (animated path); optionsFor picks the first vips-webp entry.
 		$this->assertSame(
 			[ '', '[strip=true,Q=90,smart_subsample=true]' ],
 			ThumbroVips::optionsFor( 'image/webp', $config )
 		);
+	}
+
+	/** Production routing: static webp → cwebp; jpeg/png → vips-webp. */
+	public function testProductionStaticEncoderRouting(): void {
+		$config = json_decode(
+			(string)file_get_contents( __DIR__ . '/../../../../extension.json' ), true
+		)['config']['ThumbroOptions']['value'];
+
+		$this->assertSame( 'cwebp', ThumbroVips::staticEncoderFor( 'image/webp', $config ),
+			'static image/webp routes to cwebp' );
+		$this->assertSame( 'vips-webp', ThumbroVips::staticEncoderFor( 'image/jpeg', $config ),
+			'image/jpeg stays on vips-webp' );
+		$this->assertSame( 'vips-webp', ThumbroVips::staticEncoderFor( 'image/png', $config ),
+			'image/png stays on vips-webp' );
+	}
+
+	/** Production cwebp options for static webp. */
+	public function testProductionCwebpOptionsForWebp(): void {
+		$config = json_decode(
+			(string)file_get_contents( __DIR__ . '/../../../../extension.json' ), true
+		)['config']['ThumbroOptions']['value'];
+
+		$opts = ThumbroVips::cwebpOptionsFor( 'image/webp', $config );
+		$this->assertSame( '80', $opts['q'], 'cwebp q=80' );
+		$this->assertSame( '6', $opts['m'], 'cwebp m=6' );
 	}
 }

--- a/tests/phpunit/unit/Shell/ShellCommandTest.php
+++ b/tests/phpunit/unit/Shell/ShellCommandTest.php
@@ -24,9 +24,9 @@ class ShellCommandTest extends MediaWikiUnitTestCase {
 		);
 	}
 
-	public function testGif2webpStyleFlagsAndPositionalInput(): void {
+	public function testLibwebpStyleFlagsAndPositionalInput(): void {
 		$cmd = $this->command(
-			'libwebp', '/usr/bin/gif2webp', [ 'mixed' => '', 'q' => '80', 'm' => '4' ], 'gif2webp'
+			'libwebp', '/usr/bin/gif2webp', [ 'mixed' => '', 'q' => '80', 'm' => '4' ], 'libwebp'
 		);
 		$cmd->setIO( '/tmp.gif', '/out.webp' );
 		$this->assertSame(


### PR DESCRIPTION
**Draft.** Phase 2 of the WebP work — adds a `cwebp` (libwebp) encoder to the resize→encode pipeline (merged in #79) and routes **static WebP input** to it. Builds on `main`. Intended for **rebase-merge**.

## What's here (4 commits)

1. **`refactor:`** add `CwebpEncoder` (encode-only, PNG intermediate, no animation; owns its flag formatting) + a format-neutral rename of the single-dash `ShellCommand` arg style (`gif2webp`→`libwebp`, since cwebp shares it). Registered but inert.
2. **`test(bench):`** `sweep-cwebp.php` — a cwebp parameter-sweep research tool.
3. **`perf:`** route static `image/webp` → **cwebp q80** (encode list: animated→vips-webp, static→cwebp, vips-webp catch-all). Bench contender made encoder-aware. **JPEG/PNG/GIF unchanged; animation stays vips.**
4. **`docs:`** record the per-MIME decisions.

## The result (gate-proven)

`cwebp` is ~2× more byte-efficient than vips `webpsave` on WebP photos. Static `photo.webp` flips from a size **trade-off** to a clean **win** at every width — smaller than ImageMagick at no-worse quality **and** smaller than the GD floor:

| width | Thumbro (cwebp q80) | ImageMagick | GD floor | before (vips Q90) |
|---|---|---|---|---|
| 180 | **8.3 KB / 73.8** | 20.5 KB / 71.8 | 8.7 KB / 74.1 | 26.9 KB / 79.3 (trade-off) |
| 250 | **14.4 KB / 78.7** | 25.9 KB / 73.9 | 15.1 KB / 79.3 | 38.4 KB / 87.8 (trade-off) |
| 400 | **33.1 KB / 78.1** | 42.9 KB / 72.8 | 35.0 KB / 78.6 | 68.5 KB / 86.8 (trade-off) |

Corpus summary: **15 → 18 wins**, no new loss/CAP-BREACH.

## Data-driven scope (measure-all)

Swept + benchmarked all static raster: **cwebp wins WebP only.** JPEG ties vips-webp (no gain) and PNG loses badly (catastrophic on screenshots/line-art; can't reach IM quality on the transparent logo even at q90) — so **JPEG/PNG keep vips-webp**. Recorded in `docs/encoding/`.

## Safety / notes

- **cwebp is an optional (soft) dependency** — it ships in the same `webp` apt package as the already-required `gif2webp`. If absent, the availability filter drops the cwebp entry and static WebP degrades to the vips-webp catch-all (no break).
- **Animation unchanged** — cwebp is single-image only; animated WebP stays vips-webp (a future `img2webp` path could improve it).
- No config-schema break (the Phase 1 `encode`-list schema is unchanged; this adds a `cwebp` library + a cwebp entry to the `image/webp` list).
- 161 tests pass; PHPCS 0/0; Phan blocked only by the dev container's pre-existing php-ast mismatch.

## Test plan
- [ ] CI green
- [ ] (follow-up, pre-existing) the root README config-reference section is stale from the Phase 1 schema change — worth a separate doc pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cwebp` encoder support for static WebP image encoding, expanding available encoding options.

* **Documentation**
  * Updated configuration documentation to reflect new encoder selection schema with `cwebp` as an option for static WebP outputs.
  * Updated system requirements to explicitly mention `cwebp` tool from libwebp package and its role in the encoding pipeline.
  * Added historical evaluation notes documenting encoder performance comparisons across WebP, JPEG, and PNG formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->