### PR TITLE
refactor(config)!: key ThumbroLibraries by library, nest binaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ pluggable **`Encoder`** writes the WebP. The `EncodePipeline` coordinator wires 
   (`animated`/`alpha`/`underThreshold`). `EncoderRouter` picks the first entry whose `when` the
   file satisfies; a `when`-less entry is the catch-all. There are no per-library special-cases in
   the resolver — it hands each encoder its options verbatim.
-- Binaries are configured under `wgThumbroLibraries` (`libvips` → `vipsthumbnail`, `libwebp` →
-  `gif2webp`).
+- Binaries are configured under `wgThumbroLibraries`, keyed by library, each mapping its binaries
+  by name to their paths (`libvips` → `vipsthumbnail`; `libwebp` → `gif2webp`, `cwebp`).
 - **Routing/policy is visible in config, not buried in code.** The coordinator builds the file's
   traits (animated; alpha — probed only when it can matter; area vs `$wgThumbroMaxAnimatedArea`
   → `underThreshold`), drops encoders whose tool is absent, routes via the `when` list, and

--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ wfLoadExtension( 'Thumbro' );
 > ℹ️ **Thumbro works out of the box — no configuration required.**
 
 ### `$wgThumbroLibraries`
-The image tools Thumbro can run, and the path to each binary.
-
-Key | Description
-:--- | :---
-`command` | Path to the tool's executable
+The image libraries Thumbro can run, keyed by library. Each library maps its binaries
+(by binary name) to their executable paths. `libwebp` ships two tools — `gif2webp` and
+`cwebp` — so it owns both.
 
 Default:
 ```php
 $wgThumbroLibraries = [
-	'libvips' => [ 'command' => '/usr/bin/vipsthumbnail' ], // resize (+ vips-webp encode)
-	'libwebp' => [ 'command' => '/usr/bin/gif2webp' ],      // animated-GIF encode
-	'cwebp'   => [ 'command' => '/usr/bin/cwebp' ],         // static-WebP encode
+	'libvips' => [ 'vipsthumbnail' => '/usr/bin/vipsthumbnail' ], // resize (+ vips-webp encode)
+	'libwebp' => [
+		'gif2webp' => '/usr/bin/gif2webp', // animated-GIF encode
+		'cwebp'    => '/usr/bin/cwebp',     // static-WebP encode
+	],
 ];
 ```
 

--- a/extension.json
+++ b/extension.json
@@ -96,13 +96,11 @@
 		"ThumbroLibraries": {
 			"value": {
 				"libvips": {
-					"command": "/usr/bin/vipsthumbnail"
+					"vipsthumbnail": "/usr/bin/vipsthumbnail"
 				},
 				"libwebp": {
-					"command": "/usr/bin/gif2webp"
-				},
-				"cwebp": {
-					"command": "/usr/bin/cwebp"
+					"gif2webp": "/usr/bin/gif2webp",
+					"cwebp": "/usr/bin/cwebp"
 				}
 			}
 		},

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -32,7 +32,7 @@ return [
 
 	'Thumbro.AlphaDetector' => static function ( MediaWikiServices $services ): VipsHeaderAlphaDetector {
 		$libraries = $services->getConfigFactory()->makeConfig( 'thumbro' )->get( 'ThumbroLibraries' );
-		return new VipsHeaderAlphaDetector( $libraries['libvips']['command'] ?? '' );
+		return new VipsHeaderAlphaDetector( $libraries['libvips']['vipsthumbnail'] ?? '' );
 	},
 
 	'Thumbro.CommandPlanRunner' => static function ( MediaWikiServices $services ): CommandPlanRunner {
@@ -52,15 +52,15 @@ return [
 	'Thumbro.Encoders' => static function ( MediaWikiServices $services ): array {
 		$libraries = $services->getConfigFactory()->makeConfig( 'thumbro' )->get( 'ThumbroLibraries' );
 		return [
-			'vips-webp' => new VipsWebpEncoder( $libraries['libvips']['command'] ?? '' ),
-			'gif2webp' => new Gif2webpEncoder( $libraries['libwebp']['command'] ?? '' ),
-			'cwebp' => new CwebpEncoder( $libraries['cwebp']['command'] ?? '' ),
+			'vips-webp' => new VipsWebpEncoder( $libraries['libvips']['vipsthumbnail'] ?? '' ),
+			'gif2webp' => new Gif2webpEncoder( $libraries['libwebp']['gif2webp'] ?? '' ),
+			'cwebp' => new CwebpEncoder( $libraries['libwebp']['cwebp'] ?? '' ),
 		];
 	},
 
 	'Thumbro.VipsResizer' => static function ( MediaWikiServices $services ): VipsResizer {
 		$libraries = $services->getConfigFactory()->makeConfig( 'thumbro' )->get( 'ThumbroLibraries' );
-		return new VipsResizer( $libraries['libvips']['command'] ?? '' );
+		return new VipsResizer( $libraries['libvips']['vipsthumbnail'] ?? '' );
 	},
 
 	'Thumbro.EncoderRouter' => static function ( MediaWikiServices $services ): EncoderRouter {
@@ -88,7 +88,7 @@ return [
 		$libraries = $services->getConfigFactory()->makeConfig( 'thumbro' )->get( 'ThumbroLibraries' );
 		return [
 			new LibvipsVersionProvider(),
-			new LibwebpVersionProvider( $libraries['libwebp']['command'] ?? '' ),
+			new LibwebpVersionProvider( $libraries['libwebp']['gif2webp'] ?? '' ),
 			new ImageMagickVersionProvider(),
 			new GdVersionProvider(),
 		];


### PR DESCRIPTION
## Why

`$wgThumbroLibraries` had an inconsistent organizing principle. `cwebp` is itself a libwebp tool, but the old flat layout gave it a top-level key alongside `libwebp` (which held `gif2webp`) — so the config mixed "keyed by library" with "keyed by binary", and one library (libwebp) ended up spread across two keys.

## What

Key strictly by **library**; each library maps its binaries by name to their paths:

```php
$wgThumbroLibraries = [
    'libvips' => [ 'vipsthumbnail' => '/usr/bin/vipsthumbnail' ],
    'libwebp' => [
        'gif2webp' => '/usr/bin/gif2webp',
        'cwebp'    => '/usr/bin/cwebp',
    ],
];
```

This matches the version-reporting grouping (`LibvipsVersionProvider` / `LibwebpVersionProvider` are library-scoped) and drops the redundant `command` wrapper.

- `extension.json` — new default shape
- `includes/ServiceWiring.php` — all 4 readers updated to the nested keys
- `README.md`, `AGENTS.md` — config reference refreshed

## ⚠ Breaking change

Wikis that set `$wgThumbroLibraries` **explicitly** must migrate to the nested shape (`libwebp.gif2webp`, `libwebp.cwebp`). Wikis on the default need no action.

## Benchmark gate

N/A — pure config-schema rename. No handler, encoder, resize, or encode-option behavior changes, so thumbnail output is byte-identical. The gate (size/quality/perf) applies to handler/option changes, which this is not.

## Verification

- `composer preflight`: parallel-lint, phpcs, minus-x all pass. (Phan blocked by a pre-existing env issue — php-ast 1.1.2 vs required 1.1.3+ — unrelated to this change.)
- PHPUnit: 160/161 pass. The one failure (`GdBaselineTest`) needs GNU `time` at `/usr/bin/time`, absent in the container — bench-harness env, unrelated.
  - `MediaWikiHooksTest` (passes) exercises the real config→`LibwebpVersionProvider` path and asserts Special:Version reports both libvips and libwebp.
- Runtime smoke test (service container): every encoder/resizer/version provider resolves to its configured binary; `vips-webp` available (vipsthumbnail present), `gif2webp`/`cwebp` correctly report unavailable because those binaries aren't installed in the dev container (verified absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and documentation to clarify `$wgThumbroLibraries` configuration structure, describing it as a mapping of library names to their binary executables and paths.

* **Configuration**
  * Simplified `$wgThumbroLibraries` mapping structure, replacing nested command wrappers with direct executable-path keys for `libvips` and `libwebp` binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->