### PR TITLE
fix: keep external-link wrapping of link= thumbnails intact

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -55,6 +55,7 @@
 	"Hooks": {
 		"BitmapHandlerTransform": "main",
 		"BitmapHandlerCheckImageArea": "main",
+		"LinkerMakeExternalLink": "main",
 		"SoftwareInfo": "main"
 	},
 	"HookHandlers": {

--- a/includes/Hooks/MediaWikiHooks.php
+++ b/includes/Hooks/MediaWikiHooks.php
@@ -9,11 +9,13 @@ use MediaWiki\Config\Config;
 use MediaWiki\Config\ConfigFactory;
 use MediaWiki\Extension\Thumbro\Backend\BackendRequest;
 use MediaWiki\Extension\Thumbro\Backend\EncodePipeline;
+use MediaWiki\Extension\Thumbro\Linker\CrawlerAnchorStripper;
 use MediaWiki\Extension\Thumbro\MediaHandlers;
 use MediaWiki\Extension\Thumbro\Options\TransformOptionsResolver;
 use MediaWiki\Extension\Thumbro\Version\SoftwareVersionProvider;
 use MediaWiki\Hook\BitmapHandlerCheckImageAreaHook;
 use MediaWiki\Hook\BitmapHandlerTransformHook;
+use MediaWiki\Hook\LinkerMakeExternalLinkHook;
 use MediaWiki\Hook\SoftwareInfoHook;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Shell\Shell;
@@ -22,6 +24,7 @@ use TransformationalImageHandler;
 class MediaWikiHooks implements
 	BitmapHandlerTransformHook,
 	BitmapHandlerCheckImageAreaHook,
+	LinkerMakeExternalLinkHook,
 	SoftwareInfoHook
 {
 	private readonly Config $config;
@@ -102,6 +105,29 @@ class MediaWikiHooks implements
 			wfDebug( "[Extension:Thumbro] Overriding wgMaxImageArea: $maxImageArea" );
 			$result = true;
 			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Strip Thumbro's hidden crawler anchor when a thumbnail is wrapped in an external
+	 * link. A nested <a> inside the external link's <a> is invalid HTML and breaks the
+	 * wrap (trailing text falls outside the link). The crawler anchor is preserved
+	 * everywhere else by ThumbroThumbnailImage::toHtml(); it is removed only here, where
+	 * it cannot legally live. By parser ordering (handleInternalLinks before
+	 * handleExternalLinks, both before Remex tidy) the image HTML is already materialized
+	 * in $text at this point, so the wrap comes out well-formed.
+	 *
+	 * @param string &$url
+	 * @param string &$text Link inner HTML; may contain a wrapped thumbnail
+	 * @param string &$link
+	 * @param array &$attribs
+	 * @param string $linktype
+	 * @return bool
+	 */
+	public function onLinkerMakeExternalLink( &$url, &$text, &$link, &$attribs, $linktype ) {
+		if ( is_string( $text ) ) {
+			$text = CrawlerAnchorStripper::strip( $text );
 		}
 		return true;
 	}

--- a/includes/Linker/CrawlerAnchorStripper.php
+++ b/includes/Linker/CrawlerAnchorStripper.php
@@ -1,0 +1,37 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Linker;
+
+/**
+ * Removes Thumbro's hidden crawler anchor (<a class="mw-file-source">…</a>) from an HTML
+ * fragment. Used to strip the anchor when a thumbnail is wrapped in an external link,
+ * where a nested <a> would be invalid HTML and break the wrap. The class appears nowhere
+ * in MediaWiki core, so matching on it cannot remove a core anchor.
+ *
+ * @see \MediaWiki\Extension\Thumbro\ThumbroThumbnailImage::toHtml()
+ */
+class CrawlerAnchorStripper {
+
+	/**
+	 * @param string $html HTML fragment that may contain crawler anchors
+	 * @return string The fragment with every crawler anchor removed
+	 */
+	public static function strip( string $html ): string {
+		if ( !str_contains( $html, 'mw-file-source' ) ) {
+			return $html;
+		}
+
+		// CSS classes are whitespace-delimited, so bound the token on chars that cannot
+		// appear in a class name (not \b, which treats the '-' in mw-file-source-* as a
+		// boundary and would over-match e.g. class="mw-file-source-extra"). The double
+		// quotes are coupled to Html::rawElement(), which always emits double-quoted attrs.
+		$stripped = preg_replace(
+			'#<a\b[^>]*\bclass="[^"]*(?<![-\w])mw-file-source(?![-\w])[^"]*"[^>]*>.*?</a>#s',
+			'',
+			$html
+		);
+
+		return $stripped ?? $html;
+	}
+}

--- a/tests/phpunit/integration/ExternalLinkImageWrappingTest.php
+++ b/tests/phpunit/integration/ExternalLinkImageWrappingTest.php
@@ -1,0 +1,39 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Integration;
+
+use HtmlArmor;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * Exercises the real LinkRenderer + registered LinkerMakeExternalLink hook to confirm a
+ * thumbnail's crawler anchor is stripped when wrapped in an external link, so the wrap
+ * stays valid (trailing text remains inside the link).
+ *
+ * @covers \MediaWiki\Extension\Thumbro\Hooks\MediaWikiHooks::onLinkerMakeExternalLink
+ * @covers \MediaWiki\Extension\Thumbro\Linker\CrawlerAnchorStripper
+ * @group Thumbro
+ */
+class ExternalLinkImageWrappingTest extends MediaWikiIntegrationTestCase {
+
+	public function testExternalLinkStripsWrappedCrawlerAnchor(): void {
+		$linkRenderer = $this->getServiceContainer()->getLinkRenderer();
+
+		$inner = '<picture><img src="/t.webp"></picture>'
+			. '<a href="/images/orig.png" class="mw-file-source" title="View source image">'
+			. '<!-- Image link for Crawlers --></a>Undertale';
+
+		$html = $linkRenderer->makeExternalLink(
+			'https://undertale.wiki/',
+			new HtmlArmor( $inner ),
+			Title::newFromText( 'Thumbro test' )
+		);
+
+		$this->assertStringNotContainsString( 'mw-file-source', $html );
+		$this->assertStringContainsString( '<picture><img src="/t.webp"></picture>', $html );
+		// Trailing text stays inside the single external anchor.
+		$this->assertStringContainsString( 'Undertale</a>', $html );
+	}
+}

--- a/tests/phpunit/unit/Linker/CrawlerAnchorStripperTest.php
+++ b/tests/phpunit/unit/Linker/CrawlerAnchorStripperTest.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Unit\Linker;
+
+use MediaWiki\Extension\Thumbro\Linker\CrawlerAnchorStripper;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Thumbro\Linker\CrawlerAnchorStripper
+ */
+class CrawlerAnchorStripperTest extends MediaWikiUnitTestCase {
+
+	public function testStripsSingleCrawlerAnchor(): void {
+		$picture = '<picture><img src="/t.webp" width="84" height="60"></picture>';
+		$anchor = '<a href="/images/orig.png" class="mw-file-source" title="View source image">'
+			. '<!-- Image link for Crawlers --></a>';
+		$this->assertSame( $picture, CrawlerAnchorStripper::strip( $picture . $anchor ) );
+	}
+
+	public function testStripsMultipleCrawlerAnchors(): void {
+		$a = '<a href="/a.png" class="mw-file-source"><!-- x --></a>';
+		$b = '<a href="/b.png" class="mw-file-source"><!-- y --></a>';
+		$this->assertSame( 'AB', CrawlerAnchorStripper::strip( 'A' . $a . 'B' . $b ) );
+	}
+
+	public function testLeavesFragmentWithoutMarkerUntouched(): void {
+		$html = '<picture><img src="/t.webp"></picture><a href="/x">link</a>';
+		$this->assertSame( $html, CrawlerAnchorStripper::strip( $html ) );
+	}
+
+	public function testDoesNotOverMatchUnrelatedTrailingAnchor(): void {
+		$anchor = '<a href="/orig.png" class="mw-file-source"><!-- c --></a>';
+		$keep = '<a href="/page">Undertale</a>';
+		$this->assertSame( 'IMG' . $keep, CrawlerAnchorStripper::strip( 'IMG' . $anchor . $keep ) );
+	}
+
+	public function testToleratesMultiClassValue(): void {
+		$anchor = '<a href="/orig.png" class="mw-file-source extra"><!-- c --></a>';
+		$this->assertSame( 'X', CrawlerAnchorStripper::strip( 'X' . $anchor ) );
+	}
+
+	/**
+	 * mw-file-source must match as a whole class token, not as a hyphen-segment of a
+	 * larger class name — otherwise an unrelated element would be silently deleted.
+	 */
+	public function testDoesNotMatchHyphenatedClassNames(): void {
+		$suffix = '<a href="/x" class="mw-file-source-extra">trailing</a>';
+		$this->assertSame( $suffix, CrawlerAnchorStripper::strip( $suffix ) );
+
+		$prefix = '<a href="/x" class="my-mw-file-source">trailing</a>';
+		$this->assertSame( $prefix, CrawlerAnchorStripper::strip( $prefix ) );
+	}
+}


### PR DESCRIPTION
## Problem

In stock MediaWiki, this wikitext wraps an image **and** trailing text in a single external link:

```
[https://undertale.wiki/ [[File:Flowey overworld.png|link=]]Undertale]
```

With Thumbro installed, the link breaks — the image is linked, but "Undertale" falls outside the link.

**Root cause:** `ThumbroThumbnailImage::toHtml()` appends a hidden crawler anchor (`<a class="mw-file-source" href="ORIGINAL">…</a>`) after every thumbnail so reverse-image crawlers (Google Images) can reach the original-resolution image — the visible `src` is a downscaled WebP. `link=` makes the image render as a bare `<img>` with no anchor, so stock MW has nothing illegal to wrap; Thumbro's appended `<a>` reintroduces an anchor, so the external link ends up wrapping `<a>…<a>…</a>…</a>`. Nested `<a>` is invalid HTML, so the browser (and Remex tidy) closes the outer link early and orphans the trailing text.

## Fix

Strip the crawler anchor **only at the wrapping site**, via a new `LinkerMakeExternalLink` hook. `toHtml()` is left untouched, so the crawler anchor is preserved byte-for-byte on **every** non-wrapped image (`thumb`, `frameless`, default desc-link, `link=Page`, standalone `link=`). The only anchor removed is one that was already in an invalid nested position, where it provides no reliable crawler benefit anyway.

Why the hook is the right seam: in `Parser::internalParse()`, `handleInternalLinks()` (which materializes the full image HTML, crawler anchor and all) runs **before** `handleExternalLinks()` (which fires the hook), and both run **before** Remex tidy — so at hook time the inner HTML is real and editable, and the wrap comes out well-formed from the start.

- The strip is class-scoped to `mw-file-source`, which appears nowhere in MediaWiki core, and is token-bounded so it cannot match hyphenated class names (e.g. `mw-file-source-extra`).
- Cost is a `str_contains` guard per external link, **at parse time only** (cached views pay nothing).

### Out of scope (by design)
`[url [[File:X]] text]` *without* `link=` stays broken — but by the image's **own** desc-link anchor, a pre-existing core limitation (stock MW produces the same nested `<a>`), not a Thumbro regression. Wrapping has always required `link=`.

## Testing

- **Unit** (`CrawlerAnchorStripperTest`): single/multiple strip, identity on no-marker, no over-match across an unrelated trailing `<a>`, multi-class tolerance, and hyphenated-class non-match. 7/7 green.
- **Integration** (`ExternalLinkImageWrappingTest`): drives the real `LinkRenderer` + registered hook (proves wiring).
- **Regression guard:** `ThumbroThumbnailImageTest` 4/4 green — `toHtml()` still emits the crawler anchor on normal thumbnails.
- **Live smoke test** on the dev wiki with `File:Abstract art.png`:
  - standalone `[[File:…|link=]]` → crawler anchor **present** (preserved);
  - `[https://… [[File:…|link=]]Undertale]` → renders `<a class="external text" href="…"><picture>…</picture>Undertale</a>` — one valid link, anchor stripped, text inside.
- `composer preflight` clean (parallel-lint, PHPCS, minus-x, Phan). The only suite error is a pre-existing env gap unrelated to this change (`GdBaselineTest` needs the GNU `time` binary, not installed in the container).

No benchmark-gate impact (this is HTML/hook wiring, not a media handler or option-set change) and no new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where external links containing images generated invalid HTML with nested anchor elements. The system now properly removes internal markup when wrapping media in external links, ensuring valid output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->