### PR TITLE
fix: support MediaWiki 1.46 client-scaling thumbnail API (#85)

### DIFF
--- a/includes/MediaHandlers/ThumbroHandlerTrait.php
+++ b/includes/MediaHandlers/ThumbroHandlerTrait.php
@@ -79,6 +79,9 @@ trait ThumbroHandlerTrait {
 				'clientWidth' => $params['width'],
 				'clientHeight' => $params['height'],
 				'isFilePageThumb' => $params['isFilePageThumb'] ?? false,
+				// Forwarded so MW 1.46's modifyClientThumbUrl() can still append the
+				// request-provenance query param on this shortcut path, as core does.
+				'requestProvenance' => $params['requestProvenance'] ?? null,
 			] );
 		}
 
@@ -101,19 +104,31 @@ trait ThumbroHandlerTrait {
 	 * We need to override this method to return a ThumbroThumbnailImage instance.
 	 * Since this can happen before the onBitmapHandlerTransform hook
 	 *
+	 * Absorbs two core API changes made in MW 1.46 while still supporting 1.43–1.45:
+	 *   - The array core passes here changed from the scaler params (clientWidth/clientHeight)
+	 *     to the media-handler params (width/height). We read whichever is present so the
+	 *     thumbnail keeps its on-page dimensions instead of collapsing to 0×0.
+	 *   - File::getFilePageThumbUrl() was removed in favour of File::modifyClientThumbUrl(),
+	 *     which performs the file-page cache-busting (and request-provenance) handling itself.
+	 *
 	 * @see TransformationalImageHandler::getClientScalingThumbnailImage
+	 * @see https://github.com/StarCitizenTools/mediawiki-extensions-Thumbro/issues/85
 	 *
 	 * @inheritDoc
 	 */
 	protected function getClientScalingThumbnailImage( $image, $scalerParams ) {
 		$params = [
-			'width' => $scalerParams['clientWidth'],
-			'height' => $scalerParams['clientHeight']
+			'width' => $scalerParams['clientWidth'] ?? $scalerParams['width'] ?? null,
+			'height' => $scalerParams['clientHeight'] ?? $scalerParams['height'] ?? null,
 		];
 
 		$url = $image->getUrl();
-		if ( isset( $scalerParams['isFilePageThumb'] ) && $scalerParams['isFilePageThumb'] ) {
-			// Use a versioned URL on file description pages
+		if ( method_exists( $image, 'modifyClientThumbUrl' ) ) {
+			// MW 1.46+: mirror core by delegating the file-page/versioned URL logic to the file.
+			// @phan-suppress-next-line PhanUndeclaredMethod modifyClientThumbUrl() added in MW 1.46
+			$url = $image->modifyClientThumbUrl( $url, $scalerParams );
+		} elseif ( !empty( $scalerParams['isFilePageThumb'] ) ) {
+			// MW 1.43–1.45: append a cache-busting version parameter on file description pages.
 			$url = $image->getFilePageThumbUrl( $url );
 		}
 

--- a/tests/phpunit/integration/MediaHandlers/ThumbroHandlerTraitTest.php
+++ b/tests/phpunit/integration/MediaHandlers/ThumbroHandlerTraitTest.php
@@ -26,6 +26,11 @@ class ThumbroHandlerTraitTest extends MediaWikiIntegrationTestCase {
 		$file->method( 'getMimeType' )->willReturn( 'image/webp' );
 		$file->method( 'mustRender' )->willReturn( false );
 		$file->method( 'getUrl' )->willReturn( $url );
+		if ( method_exists( File::class, 'modifyClientThumbUrl' ) ) {
+			// MW 1.46+ routes client-scaled URLs through modifyClientThumbUrl(); for a
+			// non file-page thumbnail it returns the URL unchanged, so model that identity.
+			$file->method( 'modifyClientThumbUrl' )->willReturnArgument( 0 );
+		}
 		return $file;
 	}
 
@@ -176,5 +181,109 @@ class ThumbroHandlerTraitTest extends MediaWikiIntegrationTestCase {
 			'orientation 3 (rotate 180)' => [ 3, 180 ],
 			'orientation 6 (rotate 270)' => [ 6, 270 ],
 		];
+	}
+
+	/**
+	 * Invoke the trait's protected getClientScalingThumbnailImage() via a real handler.
+	 */
+	private function invokeClientScaling( File $image, array $scalerParams ): ThumbroThumbnailImage {
+		$handler = new class extends ThumbroWebPHandler {
+			public function exposeClientScaling( File $image, array $scalerParams ): ThumbroThumbnailImage {
+				return $this->getClientScalingThumbnailImage( $image, $scalerParams );
+			}
+		};
+		return $handler->exposeClientScaling( $image, $scalerParams );
+	}
+
+	/**
+	 * A File exposing MW 1.46's modifyClientThumbUrl(). On 1.46+ the method exists natively;
+	 * on 1.43–1.45 we synthesise it so the newer code path can be exercised on every matrix row.
+	 */
+	private function makeFileWithModifyClientThumbUrl( string $url, string $modifiedUrl ): File {
+		if ( method_exists( File::class, 'modifyClientThumbUrl' ) ) {
+			$file = $this->createMock( File::class );
+		} else {
+			$file = $this->getMockBuilder( File::class )
+				->disableOriginalConstructor()
+				->onlyMethods( [ 'getUrl' ] )
+				->addMethods( [ 'modifyClientThumbUrl' ] )
+				->getMock();
+		}
+		$file->method( 'getUrl' )->willReturn( $url );
+		$file->method( 'modifyClientThumbUrl' )->willReturn( $modifiedUrl );
+		return $file;
+	}
+
+	/**
+	 * MW 1.46 changed the array passed to getClientScalingThumbnailImage() from the scaler
+	 * params (clientWidth/clientHeight) to the media-handler params (width/height). The output
+	 * must still carry the on-page dimensions rather than collapsing to a 0×0 image.
+	 *
+	 * Regression test for https://github.com/StarCitizenTools/mediawiki-extensions-Thumbro/issues/85
+	 */
+	public function testClientScalingReadsMediaHandlerDimensions(): void {
+		$file = $this->createMock( File::class );
+		$file->method( 'getUrl' )->willReturn( '/w/images/f/f5/Anvil_Carrack.webp' );
+
+		$result = $this->invokeClientScaling( $file, [
+			'width' => 300,
+			'height' => 200,
+			'isFilePageThumb' => false,
+		] );
+
+		$this->assertSame( 300, $result->getWidth(), 'width must fall back to the media-handler width' );
+		$this->assertSame( 200, $result->getHeight(), 'height must fall back to the media-handler height' );
+	}
+
+	/**
+	 * MW 1.46 removed File::getFilePageThumbUrl() in favour of modifyClientThumbUrl(). When the
+	 * newer method is available it must build the file-page URL; calling the removed method would
+	 * fatal, which is the crash reported in the issue.
+	 *
+	 * Regression test for https://github.com/StarCitizenTools/mediawiki-extensions-Thumbro/issues/85
+	 */
+	public function testClientScalingUsesModifyClientThumbUrlWhenAvailable(): void {
+		$modifiedUrl = '/w/images/f/f5/Anvil_Carrack.webp?_=20200101000000';
+		$file = $this->makeFileWithModifyClientThumbUrl( '/w/images/f/f5/Anvil_Carrack.webp', $modifiedUrl );
+
+		$result = $this->invokeClientScaling( $file, [
+			'width' => 300,
+			'height' => 200,
+			'isFilePageThumb' => true,
+		] );
+
+		$this->assertSame(
+			$modifiedUrl,
+			$result->getUrl(),
+			'MW 1.46 must version the file-page URL through modifyClientThumbUrl()'
+		);
+	}
+
+	/**
+	 * On MW 1.43–1.45 (before modifyClientThumbUrl() existed) the file-page thumbnail URL must
+	 * still be versioned through getFilePageThumbUrl(), reading dimensions from the scaler params.
+	 */
+	public function testClientScalingUsesFilePageThumbUrlOnLegacyCore(): void {
+		if ( method_exists( File::class, 'modifyClientThumbUrl' ) ) {
+			$this->markTestSkipped( 'File::getFilePageThumbUrl() was removed in MW 1.46' );
+		}
+
+		$legacyUrl = '/w/images/f/f5/Anvil_Carrack.webp?20200101000000';
+		$file = $this->createMock( File::class );
+		$file->method( 'getUrl' )->willReturn( '/w/images/f/f5/Anvil_Carrack.webp' );
+		$file->method( 'getFilePageThumbUrl' )->willReturn( $legacyUrl );
+
+		$result = $this->invokeClientScaling( $file, [
+			'clientWidth' => 300,
+			'clientHeight' => 200,
+			'isFilePageThumb' => true,
+		] );
+
+		$this->assertSame(
+			$legacyUrl,
+			$result->getUrl(),
+			'Legacy core must version the file-page URL through getFilePageThumbUrl()'
+		);
+		$this->assertSame( 300, $result->getWidth() );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #85 — Thumbro 2.0.0 crashes on MediaWiki 1.46 with `Call to undefined method File::getFilePageThumbUrl()` on file description pages, and renders every thumbnail button at 0 × 0 pixels.

MW 1.46 made two simultaneous changes to the `TransformationalImageHandler::getClientScalingThumbnailImage` contract that `ThumbroHandlerTrait` overrides (the transition is exactly 1.45 → 1.46; 1.43/1.44/1.45 share the old contract):

1. **`File::getFilePageThumbUrl()` was removed**, replaced by `File::modifyClientThumbUrl($url, $handlerParams)` (which now performs the file-page cache-busting *and* request-provenance handling itself). Calling the removed method is the fatal crash.
2. **The array core passes to the method changed shape** — from the *scaler* params (`clientWidth`/`clientHeight`) to the *media-handler* params (`width`/`height`). The override read only `clientWidth`/`clientHeight` → `null` → `(int)round(null)` = `0`, hence the 0 × 0 thumbnails.

## Changes

- **`includes/MediaHandlers/ThumbroHandlerTrait.php`**
  - Dimensions read `clientWidth ?? width` / `clientHeight ?? height`, so both array shapes work.
  - URL routing is **capability-detected** (`method_exists`, not `MW_VERSION`): `modifyClientThumbUrl()` on 1.46+ (mirroring core, unconditionally, so request-provenance is preserved), otherwise the `isFilePageThumb`-guarded `getFilePageThumbUrl()` on 1.43–1.45. Behaviour on 1.43–1.45 is unchanged.
  - Forwards `requestProvenance` through `doTransform`'s unscaled-guard shortcut so 1.46's provenance param survives that path too, matching core.
- **`tests/phpunit/integration/MediaHandlers/ThumbroHandlerTraitTest.php`** — three regression tests: media-handler dimension fallback (the 0 × 0 case), `modifyClientThumbUrl()` routing on 1.46+, and `getFilePageThumbUrl()` routing on legacy. They use version-aware test doubles so they pass on the whole `REL1_43`/`REL1_44`/`REL1_45`/`REL1_46` PHPUnit matrix.

## Testing

- Full `composer preflight` green on MW 1.43: parallel-lint, PHPCS 53/53 (no warnings), minus-x, Phan (clean), PHPUnit 189/189.
- Confirmed the new tests fail against the pre-fix code (reproducing `Undefined array key "clientWidth"`) and pass after the fix.
- Local dev Docker is pinned to 1.43; the 1.44/1.45/1.46 rows are covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
