### PR TITLE
fix: keep the crawler anchor out of the tab order and a11y tree

### DIFF
--- a/includes/Linker/CrawlerAnchorStripper.php
+++ b/includes/Linker/CrawlerAnchorStripper.php
@@ -9,6 +9,9 @@ namespace MediaWiki\Extension\Thumbro\Linker;
  * where a nested <a> would be invalid HTML and break the wrap. The class appears nowhere
  * in MediaWiki core, so matching on it cannot remove a core anchor.
  *
+ * The anchor also carries tabindex="-1" and aria-hidden="true"; the regex matches on the
+ * class token alone and so is agnostic to those (or any future) attributes.
+ *
  * @see \MediaWiki\Extension\Thumbro\ThumbroThumbnailImage::toHtml()
  */
 class CrawlerAnchorStripper {

--- a/includes/ThumbroThumbnailImage.php
+++ b/includes/ThumbroThumbnailImage.php
@@ -181,13 +181,15 @@ class ThumbroThumbnailImage extends ThumbnailImage {
 
 		$p .= Html::closeElement( 'picture' );
 
+		// Hidden crawler-discoverable link to the original-resolution file (T54647); the <img>
+		// only ever carries a thumbnail, so this is the sole place the source URL appears.
 		$sourceLink = Html::rawElement(
 			'a',
 			[
 				'href' => $this->file->getUrl(),
 				'class' => 'mw-file-source',
-				// FIXME: Need i18n
-				'title' => 'View source image'
+				'tabindex' => '-1',
+				'aria-hidden' => 'true',
 			],
 			'<!-- Image link for Crawlers -->'
 		);

--- a/tests/phpunit/integration/ExternalLinkImageWrappingTest.php
+++ b/tests/phpunit/integration/ExternalLinkImageWrappingTest.php
@@ -22,8 +22,8 @@ class ExternalLinkImageWrappingTest extends MediaWikiIntegrationTestCase {
 		$linkRenderer = $this->getServiceContainer()->getLinkRenderer();
 
 		$inner = '<picture><img src="/t.webp"></picture>'
-			. '<a href="/images/orig.png" class="mw-file-source" title="View source image">'
-			. '<!-- Image link for Crawlers --></a>Undertale';
+			. '<a href="/images/orig.png" class="mw-file-source" tabindex="-1"'
+			. ' aria-hidden="true"><!-- Image link for Crawlers --></a>Undertale';
 
 		$html = $linkRenderer->makeExternalLink(
 			'https://undertale.wiki/',

--- a/tests/phpunit/integration/ThumbroThumbnailImageTest.php
+++ b/tests/phpunit/integration/ThumbroThumbnailImageTest.php
@@ -34,12 +34,20 @@ class ThumbroThumbnailImageTest extends MediaWikiIntegrationTestCase {
 		$this->assertStringContainsString( 'decoding="async"', $html );
 	}
 
+	/**
+	 * The hidden anchor lets crawlers reach the original-resolution image (T54647). It renders
+	 * at zero size but is a real <a href>, so tabindex and aria-hidden keep it out of the tab
+	 * order and the accessibility tree (#97) — neither has any visible effect, so only an
+	 * exact-markup pin would catch their removal.
+	 */
 	public function testRendersHiddenCrawlerAnchorToOriginal(): void {
 		$html = $this->image( '/w/thumb/84px-t.webp', '/w/images/original.gif', 84, 84 )->toHtml( [] );
 
-		// The hidden anchor lets crawlers reach the original-resolution image (T54647).
-		$this->assertStringContainsString( 'mw-file-source', $html );
-		$this->assertStringContainsString( 'href="/w/images/original.gif"', $html );
+		$this->assertStringContainsString(
+			'<a href="/w/images/original.gif" class="mw-file-source" tabindex="-1"'
+				. ' aria-hidden="true"><!-- Image link for Crawlers --></a>',
+			$html
+		);
 	}
 
 	public function testNoDimensionsOptionOmitsWidthHeight(): void {

--- a/tests/phpunit/unit/Linker/CrawlerAnchorStripperTest.php
+++ b/tests/phpunit/unit/Linker/CrawlerAnchorStripperTest.php
@@ -13,9 +13,20 @@ class CrawlerAnchorStripperTest extends MediaWikiUnitTestCase {
 
 	public function testStripsSingleCrawlerAnchor(): void {
 		$picture = '<picture><img src="/t.webp" width="84" height="60"></picture>';
-		$anchor = '<a href="/images/orig.png" class="mw-file-source" title="View source image">'
-			. '<!-- Image link for Crawlers --></a>';
+		$anchor = '<a href="/images/orig.png" class="mw-file-source" tabindex="-1"'
+			. ' aria-hidden="true"><!-- Image link for Crawlers --></a>';
 		$this->assertSame( $picture, CrawlerAnchorStripper::strip( $picture . $anchor ) );
+	}
+
+	/**
+	 * The regex keys on the class token alone, so it must survive any reordering of the
+	 * attribute array in ThumbroThumbnailImage::toHtml() — including attributes emitted
+	 * before class.
+	 */
+	public function testStripsAnchorRegardlessOfAttributeOrder(): void {
+		$anchor = '<a tabindex="-1" aria-hidden="true" class="mw-file-source" href="/orig.png">'
+			. '<!-- Image link for Crawlers --></a>';
+		$this->assertSame( 'X', CrawlerAnchorStripper::strip( 'X' . $anchor ) );
 	}
 
 	public function testStripsMultipleCrawlerAnchors(): void {


### PR DESCRIPTION
Closes #97.

Every Thumbro thumbnail is followed by a crawler-only anchor to the original-resolution file (T54647). Its only content is an HTML comment, so it renders at zero size — but it is still an ordinary `<a href>`, so each thumbnail contributed **one invisible keyboard tab stop**, and a gallery read to a screen reader as a run of identical nameless links.

```html
<a href="…" class="mw-file-source" tabindex="-1" aria-hidden="true"><!-- Image link for Crawlers --></a>
```

## Why the crawl purpose is unaffected

Google gates link extraction on the `<a>` + `href` alone; its own "Google can parse" examples list `<a href="…" class="pretty">` and `<a href="…" onclick="…">`, showing non-`href` attributes are irrelevant to parsing, and none of them carry a `title`. Neither `tabindex` nor `aria-hidden` appears anywhere in Google's or Bing's crawling documentation.

That matters here because the anchor's job is **URL discovery**, not image association: on a stock wiki the source URL appears nowhere crawlable — the `<img>` carries a thumbnail, and the thumbnail listings that do link originals are NOINDEX'd. T54647 puts it directly: *"Google will never get to find out that the original image files exist."*

## The dropped `title`

The hardcoded `title="View source image"` and its `// FIXME: Need i18n` are gone rather than localised. It was added during implementation in 210cff0 and was **not** part of the markup validated in T54647#9335836, which used `href` + `class` only and still moved Google Images from a 128×72 thumbnail to the 4208×2367 original. With `aria-hidden` nothing surfaces it, and its only documented use — Google's anchor-text fallback for an empty `<a>` — would supply a wiki-wide constant carrying no descriptive content about any specific image. Dropping it also avoids sending translatewiki a string documented as never visible to a reader.

## Evidence

Real Chrome, CDP-dispatched Tab presses across a six-thumbnail page:

| | before | after |
|---|---|---|
| added tab stops | **3** (one per thumbnail) | **0** |
| accessibility tree | `link "View source image"` ×3 | `ignored` |
| axe-core `aria-hidden-focus` | n/a | passes, 0 incomplete |
| rendered box | 0×0 | 0×0 (unchanged) |

Both halves of the attribute pairing were checked empirically: `aria-hidden` without `tabindex` is a **serious** axe `aria-hidden-focus` violation, and `tabindex` without `aria-hidden` leaves the anchor in the accessibility tree. They must not be split — the exact-markup test enforces that.

`composer preflight` green: parallel-lint, PHPCS 53/53 with no warnings, minus-x, Phan, PHPUnit **193 tests / 370 assertions**.

## Notes for review

- **Expect no axe delta.** The old markup was not an axe violation either — the `title` gave it an accessible name. There is no axe rule for a zero-size tab stop, so the case rests on WCAG 2.4.7 and real keyboard/screen-reader use, not on a scan diff.
- **The zero-height line box remains.** Removing it needs CSS on every page view; out of scope here.
- **Existing pages serve the old anchor until the parser cache is purged.**
- `CrawlerAnchorStripper`'s regex keys on the class token alone, so it is unaffected by attribute order; a new test pins that contract.
- No i18n changes, no new messages, no `extension.json` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYtMioqiBfF9mc8z2BMVH6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Hidden crawler links are now removed from keyboard navigation and assistive technology exposure.
  * Removed the untranslated “View source image” tooltip from these links.

* **Bug Fixes**
  * Crawler link processing now remains reliable regardless of attribute order or additional accessibility attributes.

* **Tests**
  * Added coverage verifying inert link behavior, exact accessibility attributes, title removal, and consistent link stripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->