### PR TITLE
feat: emit the crawler anchor under Parsoid read views

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -230,5 +230,18 @@
 	"ConfigRegistry": {
 		"thumbro": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
-	"manifest_version": 2
+	"manifest_version": 2,
+	"ParsoidModules": [
+		{
+			"name": "Thumbro",
+			"domProcessors": [
+				{
+					"class": "MediaWiki\\Extension\\Thumbro\\Parsoid\\CrawlerAnchorProcessor",
+					"services": [
+						"RepoGroup"
+					]
+				}
+			]
+		}
+	]
 }

--- a/includes/Linker/CrawlerAnchor.php
+++ b/includes/Linker/CrawlerAnchor.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Linker;
+
+use MediaWiki\Html\Html;
+
+/**
+ * Builds Thumbro's hidden crawler anchor — the link that makes the original-resolution
+ * file reachable by search engines (T54647). On a stock wiki the source URL appears
+ * nowhere crawlable: the <img> carries a thumbnail, and the thumbnail listings that do
+ * link originals are NOINDEX'd.
+ *
+ * Two code paths emit this anchor, because each parser exposes the file differently:
+ * ThumbroThumbnailImage::toHtml() has the File object at construction time, while
+ * Parsoid output is post-processed and identifies files by the img's `resource`
+ * attribute. The markup itself lives here so those paths cannot drift.
+ *
+ * @see \MediaWiki\Extension\Thumbro\ThumbroThumbnailImage::toHtml()
+ * @see \MediaWiki\Extension\Thumbro\Linker\ParsoidCrawlerAnchorInjector
+ */
+class CrawlerAnchor {
+
+	/** Class marking the anchor; matched by the stripper and the injector's idempotency check. */
+	public const CLASS_NAME = 'mw-file-source';
+
+	/** Text of the anchor's comment payload, without the delimiters. */
+	public const COMMENT_TEXT = ' Image link for Crawlers ';
+
+	/** Sole content of the anchor — it has no text, so it renders at zero size. */
+	public const CONTENT = '<!--' . self::COMMENT_TEXT . '-->';
+
+	/**
+	 * The anchor's attributes. Both emitting paths build from this array — the string
+	 * path via build(), the DOM path by setting each pair — so neither can drift.
+	 *
+	 * Inert for humans, intact for crawlers, which honour neither attribute. tabindex and
+	 * aria-hidden must stay together: aria-hidden on a focusable element is itself a WCAG
+	 * 4.1.2 failure, and tabindex alone would leave a screen reader announcing one
+	 * nameless link per thumbnail (#97).
+	 *
+	 * @param string $sourceUrl URL of the original-resolution file
+	 * @return array<string,string>
+	 */
+	public static function attributes( string $sourceUrl ): array {
+		return [
+			'href' => $sourceUrl,
+			'class' => self::CLASS_NAME,
+			'tabindex' => '-1',
+			'aria-hidden' => 'true',
+		];
+	}
+
+	/**
+	 * @param string $sourceUrl URL of the original-resolution file
+	 * @return string HTML for the anchor
+	 */
+	public static function build( string $sourceUrl ): string {
+		return Html::rawElement( 'a', self::attributes( $sourceUrl ), self::CONTENT );
+	}
+}

--- a/includes/Linker/CrawlerAnchorStripper.php
+++ b/includes/Linker/CrawlerAnchorStripper.php
@@ -12,6 +12,8 @@ namespace MediaWiki\Extension\Thumbro\Linker;
  * The anchor also carries tabindex="-1" and aria-hidden="true"; the regex matches on the
  * class token alone and so is agnostic to those (or any future) attributes.
  *
+ * @see \MediaWiki\Extension\Thumbro\Linker\CrawlerAnchor
+ *
  * @see \MediaWiki\Extension\Thumbro\ThumbroThumbnailImage::toHtml()
  */
 class CrawlerAnchorStripper {

--- a/includes/Parsoid/CrawlerAnchorProcessor.php
+++ b/includes/Parsoid/CrawlerAnchorProcessor.php
@@ -1,0 +1,175 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Parsoid;
+
+use MediaWiki\Extension\Thumbro\Linker\CrawlerAnchor;
+use MediaWiki\Title\Title;
+use RepoGroup;
+use Wikimedia\Parsoid\DOM\Document;
+use Wikimedia\Parsoid\DOM\DocumentFragment;
+use Wikimedia\Parsoid\DOM\Element;
+use Wikimedia\Parsoid\DOM\Node;
+use Wikimedia\Parsoid\Ext\DOMProcessor;
+use Wikimedia\Parsoid\Ext\DOMUtils;
+use Wikimedia\Parsoid\Ext\ParsoidExtensionAPI;
+use Wikimedia\Parsoid\Utils\DOMCompat;
+
+/**
+ * Adds Thumbro's crawler anchor to Parsoid-generated media.
+ *
+ * Parsoid builds the media DOM itself and never calls
+ * ThumbroThumbnailImage::toHtml(), so without this the original-resolution URL is absent
+ * from Parsoid read views entirely and T54647 fully regresses — on a stock wiki that URL
+ * appears nowhere crawlable, because the <img> carries a thumbnail and the thumbnail
+ * listings that do link originals are NOINDEX'd.
+ *
+ * Runs as a Parsoid DOM processor rather than a post-parse hook so the work happens on the
+ * live DOM inside the parse: no re-parse, no re-serialize, and therefore no risk of
+ * disturbing data-parsoid/data-mw, which are held off-DOM in a node-data bag during the
+ * parse and written back by Parsoid itself.
+ *
+ * Ordering: `extpp` runs after the `media` pass, so AddMediaInfo has already replaced the
+ * placeholder with the real <img> by the time this sees the tree.
+ */
+class CrawlerAnchorProcessor extends DOMProcessor {
+
+	public function __construct( private readonly RepoGroup $repoGroup ) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function wtPostprocess(
+		ParsoidExtensionAPI $extApi, Node $root, array $options
+	): void {
+		// The interface types $root as Node; Parsoid documents it as DocumentFragment|Element
+		// and only those can be queried.
+		if ( !$root instanceof Element && !$root instanceof DocumentFragment ) {
+			return;
+		}
+
+		foreach ( DOMCompat::querySelectorAll( $root, 'img.mw-file-element[resource]' ) as $img ) {
+			$container = $this->findMediaContainer( $img );
+			if ( !$container ) {
+				continue;
+			}
+
+			// Idempotency: never add a second anchor to the same container.
+			if ( DOMCompat::querySelector( $container, 'a.' . CrawlerAnchor::CLASS_NAME ) ) {
+				continue;
+			}
+
+			$url = $this->resolveSourceUrl( DOMCompat::getAttribute( $img, 'resource' ) ?? '' );
+			if ( $url === null ) {
+				continue;
+			}
+
+			$wrapper = $this->findMediaWrapper( $img, $container );
+			if ( !$wrapper ) {
+				continue;
+			}
+
+			// Parsoid's DOM\Document is a class_alias, so this is a no-op at runtime; the
+			// check narrows the type for static analysis, which resolves the alias
+			// differently across the supported MediaWiki versions.
+			$doc = $img->ownerDocument;
+			if ( !$doc instanceof Document ) {
+				continue;
+			}
+
+			$anchor = $this->buildAnchor( $doc, $url );
+			if ( !$anchor ) {
+				continue;
+			}
+
+			// After the media wrapper, never as the container's first child:
+			// MediaStructure::parse() takes the first non-separator child as the link
+			// element, would find this anchor's comment where the media element belongs,
+			// and return null — which makes figureHandler() emit nothing and silently
+			// deletes the image on the next save.
+			$container->insertBefore( $anchor, $wrapper->nextSibling );
+		}
+	}
+
+	/**
+	 * The <figure> or <span> carrying a mw:File typeof that encloses this media element.
+	 *
+	 * @param Element $img
+	 * @return Element|null
+	 */
+	private function findMediaContainer( Element $img ): ?Element {
+		$node = $img->parentNode;
+		while ( $node instanceof Element ) {
+			// typeof is multi-valued and Parsoid PREPENDS to it, so template-generated
+			// media reads "mw:Transclusion mw:File/Thumb". A prefix test would miss every
+			// infobox image on the wiki.
+			if ( DOMUtils::matchTypeOf( $node, '#^mw:File($|/)#D' ) !== null ) {
+				return $node;
+			}
+			$node = $node->parentNode;
+		}
+		return null;
+	}
+
+	/**
+	 * The direct child of $container holding $img — the <a> for linked media, or a bare
+	 * <span> for link=.
+	 *
+	 * @param Element $img
+	 * @param Element $container
+	 * @return Element|null
+	 */
+	private function findMediaWrapper( Element $img, Element $container ): ?Element {
+		$node = $img;
+		while ( $node->parentNode !== $container ) {
+			$parent = $node->parentNode;
+			if ( !( $parent instanceof Element ) ) {
+				return null;
+			}
+			$node = $parent;
+		}
+		return $node;
+	}
+
+	/**
+	 * Resolve the img's `resource` attribute to the original file's URL. The file is
+	 * resolved properly rather than deriving a URL from the thumbnail path, which is
+	 * silently wrong for foreign repos and custom thumb scripts.
+	 *
+	 * @param string $resource
+	 * @return string|null
+	 */
+	private function resolveSourceUrl( string $resource ): ?string {
+		if ( !str_starts_with( $resource, './' ) ) {
+			// Parsoid's spec form for `resource` is a relative title. Anything else is not
+			// something this pass should guess at.
+			return null;
+		}
+
+		$title = Title::newFromText( rawurldecode( substr( $resource, 2 ) ) );
+		if ( !$title || $title->getNamespace() !== NS_FILE ) {
+			return null;
+		}
+
+		$file = $this->repoGroup->findFile( $title );
+		return $file ? $file->getUrl() : null;
+	}
+
+	/**
+	 * @param Document $doc
+	 * @param string $url
+	 * @return Element|null
+	 */
+	private function buildAnchor( Document $doc, string $url ): ?Element {
+		$anchor = $doc->createElement( 'a' );
+		if ( !$anchor instanceof Element ) {
+			return null;
+		}
+		foreach ( CrawlerAnchor::attributes( $url ) as $name => $value ) {
+			$anchor->setAttribute( $name, $value );
+		}
+		$anchor->appendChild( $doc->createComment( CrawlerAnchor::COMMENT_TEXT ) );
+		return $anchor;
+	}
+}

--- a/includes/ThumbroThumbnailImage.php
+++ b/includes/ThumbroThumbnailImage.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Thumbro;
 
 use InvalidArgumentException;
 use MediaWiki\Extension\Thumbro\Hooks\HookRunner as ThumbroHookRunner;
+use MediaWiki\Extension\Thumbro\Linker\CrawlerAnchor;
 use MediaWiki\HookContainer\HookRunner;
 use MediaWiki\Html\Html;
 use MediaWiki\MainConfigNames;
@@ -183,16 +184,9 @@ class ThumbroThumbnailImage extends ThumbnailImage {
 
 		// Hidden crawler-discoverable link to the original-resolution file (T54647); the <img>
 		// only ever carries a thumbnail, so this is the sole place the source URL appears.
-		$sourceLink = Html::rawElement(
-			'a',
-			[
-				'href' => $this->file->getUrl(),
-				'class' => 'mw-file-source',
-				'tabindex' => '-1',
-				'aria-hidden' => 'true',
-			],
-			'<!-- Image link for Crawlers -->'
-		);
+		// Parsoid never calls toHtml(), so its output gets the same anchor added
+		// post-parse by ParsoidCrawlerAnchorInjector.
+		$sourceLink = CrawlerAnchor::build( $this->file->getUrl() );
 
 		return $this->linkWrap( $linkAttribs, $p ) . $sourceLink;
 	}

--- a/tests/phpunit/integration/Parsoid/CrawlerAnchorProcessorTest.php
+++ b/tests/phpunit/integration/Parsoid/CrawlerAnchorProcessorTest.php
@@ -1,0 +1,219 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Integration\Parsoid;
+
+use File;
+use MediaWiki\Extension\Thumbro\Parsoid\CrawlerAnchorProcessor;
+use MediaWikiIntegrationTestCase;
+use RepoGroup;
+use Wikimedia\Parsoid\Ext\ParsoidExtensionAPI;
+use Wikimedia\Parsoid\Utils\DOMCompat;
+use Wikimedia\Parsoid\Utils\DOMUtils;
+
+/**
+ * The media fragments are real Parsoid output, captured from a live wiki rendering the
+ * media shapes wikitext can produce, so the fixtures cannot drift from what Parsoid emits.
+ *
+ * Note the asymmetry they encode: `resource` is on every img, but `a.mw-file-description`
+ * on only some — link=Page has a different anchor and link= has none. Keying on the
+ * description anchor would silently miss those, which is why the processor keys on
+ * `resource`.
+ *
+ * `resource` is the relative spec form here because that is what Parsoid hands a DOM
+ * processor during the parse; the absolute URLs visible in rendered markup come from a
+ * later expansion step.
+ *
+ * @covers \MediaWiki\Extension\Thumbro\Parsoid\CrawlerAnchorProcessor
+ * @group Thumbro
+ */
+class CrawlerAnchorProcessorTest extends MediaWikiIntegrationTestCase {
+
+	private const SOURCE_URL = '/w/images/a/a9/PdImg.png';
+
+	private const THUMB = '<figure typeof="mw:File/Thumb">'
+		. '<a href="./File:PdImg.png" class="mw-file-description">'
+		. '<img resource="./File:PdImg.png" src="/w/images/thumb/a/a9/PdImg.png/300px-PdImg.png.webp"'
+		. ' class="mw-file-element"/></a><figcaption>cap</figcaption></figure>';
+
+	private const LINK_PAGE = '<span typeof="mw:File">'
+		. '<a href="./Main_Page" title="Main Page">'
+		. '<img resource="./File:PdImg.png" src="/w/images/thumb/a/a9/PdImg.png/200px-PdImg.png.webp"'
+		. ' class="mw-file-element"/></a></span>';
+
+	private const LINK_NONE = '<span typeof="mw:File"><span>'
+		. '<img resource="./File:PdImg.png" src="/w/images/thumb/a/a9/PdImg.png/200px-PdImg.png.webp"'
+		. ' class="mw-file-element"/></span></span>';
+
+	// Gallery: media sits inside <li class="gallerybox"><div class="thumb">, and Parsoid uses
+	// the same span[typeof=mw:File] wrapper it uses elsewhere. Captured from a live wiki.
+	private const GALLERY = '<ul class="gallery mw-gallery-traditional" typeof="mw:Extension/gallery">'
+		. '<li class="gallerybox" style="width: 155px;"><div class="thumb" style="width: 150px;">'
+		. '<span typeof="mw:File">'
+		. '<a href="./File:PdImg.png" class="mw-file-description" title="first">'
+		. '<img alt="first" resource="./File:PdImg.png"'
+		. ' src="/w/images/thumb/a/a9/PdImg.png/120px-PdImg.png.webp" class="mw-file-element"/>'
+		. '</a></span></div><div class="gallerytext">first</div></li>'
+		. '<li class="gallerybox" style="width: 155px;"><div class="thumb" style="width: 150px;">'
+		. '<span typeof="mw:File">'
+		. '<a href="./File:PdImg.png" class="mw-file-description" title="second">'
+		. '<img alt="second" resource="./File:PdImg.png"'
+		. ' src="/w/images/thumb/a/a9/PdImg.png/120px-PdImg.png.webp" class="mw-file-element"/>'
+		. '</a></span></div><div class="gallerytext">second</div></li></ul>';
+
+	// Template-generated media: Parsoid PREPENDS to typeof, so mw:File is not the first token.
+	private const TRANSCLUDED = '<figure typeof="mw:Transclusion mw:File/Thumb" about="#mwt1">'
+		. '<a href="./File:PdImg.png" class="mw-file-description">'
+		. '<img resource="./File:PdImg.png" src="/w/images/thumb/a/a9/PdImg.png/300px-PdImg.png.webp"'
+		. ' class="mw-file-element"/></a></figure>';
+
+	private function processor( ?string $url = self::SOURCE_URL ): CrawlerAnchorProcessor {
+		$repoGroup = $this->createMock( RepoGroup::class );
+		if ( $url === null ) {
+			$repoGroup->method( 'findFile' )->willReturn( false );
+		} else {
+			$file = $this->createMock( File::class );
+			$file->method( 'getUrl' )->willReturn( $url );
+			$repoGroup->method( 'findFile' )->willReturn( $file );
+		}
+		return new CrawlerAnchorProcessor( $repoGroup );
+	}
+
+	/**
+	 * Runs the processor over a fragment the way Parsoid's extpp pass would, and returns
+	 * the resulting body HTML.
+	 */
+	private function process( string $body, ?string $url = self::SOURCE_URL ): string {
+		$doc = DOMUtils::parseHTML( '<body>' . $body . '</body>' );
+		$root = DOMCompat::getBody( $doc );
+		$this->processor( $url )->wtPostprocess(
+			$this->createMock( ParsoidExtensionAPI::class ),
+			$root,
+			[]
+		);
+		return DOMCompat::getInnerHTML( $root );
+	}
+
+	private function anchorCount( string $html ): int {
+		return preg_match_all( '#class="mw-file-source"#', $html );
+	}
+
+	public static function provideMediaShapes(): array {
+		return [
+			'thumb' => [ self::THUMB ],
+			'link=Page' => [ self::LINK_PAGE ],
+			'link= (no anchor)' => [ self::LINK_NONE ],
+			'template-generated' => [ self::TRANSCLUDED ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideMediaShapes
+	 */
+	public function testAddsAnchorToEveryMediaShape( string $shape ): void {
+		$out = $this->process( $shape );
+
+		$this->assertSame( 1, $this->anchorCount( $out ) );
+		$this->assertStringContainsString( 'href="' . self::SOURCE_URL . '"', $out );
+		$this->assertStringContainsString( 'tabindex="-1"', $out );
+		$this->assertStringContainsString( 'aria-hidden="true"', $out );
+	}
+
+	/**
+	 * Galleries nest the media wrapper inside <li class="gallerybox"><div class="thumb">, so
+	 * the container walk has further to climb than in the inline shapes. The gallery's own
+	 * <ul> carries typeof="mw:Extension/gallery", which must not be mistaken for the media
+	 * container.
+	 */
+	public function testAddsAnchorToEachGalleryItem(): void {
+		$out = $this->process( self::GALLERY );
+
+		$this->assertSame( 2, $this->anchorCount( $out ) );
+		$this->assertStringContainsString( 'href="' . self::SOURCE_URL . '"', $out );
+		// Captions and gallery structure survive.
+		$this->assertStringContainsString( 'gallerytext">first', $out );
+		$this->assertStringContainsString( 'gallerytext">second', $out );
+		$this->assertSame( 2, preg_match_all( '#class="gallerybox"#', $out ) );
+	}
+
+	/**
+	 * The anchor belongs to the media container (the span), not the gallery <ul> or the
+	 * <li> — putting it elsewhere would break the gallery layout and, on the <ul>, would
+	 * associate one anchor with a whole gallery instead of each image.
+	 */
+	public function testGalleryAnchorSitsBesideItsOwnMedia(): void {
+		$doc = DOMUtils::parseHTML( '<body>' . $this->process( self::GALLERY ) . '</body>' );
+
+		foreach ( DOMCompat::querySelectorAll( DOMCompat::getBody( $doc ), 'a.mw-file-source' ) as $a ) {
+			$parent = $a->parentNode;
+			$this->assertInstanceOf( \Wikimedia\Parsoid\DOM\Element::class, $parent );
+			$this->assertNotNull(
+				DOMUtils::matchTypeOf( $parent, '#^mw:File($|/)#D' ),
+				'anchor must be a child of the media container, not the gallery or list item'
+			);
+		}
+	}
+
+	public function testAddsOneAnchorPerImage(): void {
+		$out = $this->process( self::THUMB . self::LINK_PAGE . self::LINK_NONE . self::TRANSCLUDED );
+
+		$this->assertSame( 4, $this->anchorCount( $out ) );
+	}
+
+	/**
+	 * The anchor must never become the media container's first child: MediaStructure::parse()
+	 * takes the first non-separator child as the link element, would find this anchor's
+	 * comment where the media element belongs, and return null — which makes figureHandler()
+	 * emit nothing and silently deletes the image on the next save.
+	 *
+	 * @dataProvider provideMediaShapes
+	 */
+	public function testAnchorIsNeverTheContainersFirstChild( string $shape ): void {
+		$doc = DOMUtils::parseHTML( '<body>' . $this->process( $shape ) . '</body>' );
+
+		$containers = 0;
+		foreach ( DOMCompat::querySelectorAll( DOMCompat::getBody( $doc ), 'figure, span' ) as $el ) {
+			if ( DOMUtils::matchTypeOf( $el, '#^mw:File($|/)#D' ) === null ) {
+				continue;
+			}
+			$containers++;
+			$first = $el->firstChild;
+			$this->assertInstanceOf( \Wikimedia\Parsoid\DOM\Element::class, $first );
+			$this->assertNotSame(
+				'mw-file-source',
+				DOMCompat::getAttribute( $first, 'class' ),
+				'anchor must not be the media container\'s first child'
+			);
+		}
+		$this->assertGreaterThan( 0, $containers, 'fixture must contain a media container' );
+	}
+
+	public function testIsIdempotent(): void {
+		$once = $this->process( self::THUMB );
+		$twice = $this->process( $once );
+
+		$this->assertSame( 1, $this->anchorCount( $twice ) );
+	}
+
+	public function testUnresolvableFileIsSkippedRatherThanEmittingABrokenAnchor(): void {
+		$this->assertSame( 0, $this->anchorCount( $this->process( self::THUMB, null ) ) );
+	}
+
+	public function testIgnoresResourceOutsideTheFileNamespace(): void {
+		$body = str_replace( 'resource="./File:PdImg.png"', 'resource="./Main_Page"', self::THUMB );
+
+		$this->assertSame( 0, $this->anchorCount( $this->process( $body ) ) );
+	}
+
+	public function testLeavesMediaWithoutResourceAlone(): void {
+		$body = str_replace( ' resource="./File:PdImg.png"', '', self::THUMB );
+
+		$this->assertSame( 0, $this->anchorCount( $this->process( $body ) ) );
+	}
+
+	public function testCaptionIsPreserved(): void {
+		$out = $this->process( self::THUMB );
+
+		$this->assertStringContainsString( 'cap</figcaption>', $out );
+	}
+}

--- a/tests/phpunit/unit/Linker/CrawlerAnchorTest.php
+++ b/tests/phpunit/unit/Linker/CrawlerAnchorTest.php
@@ -1,0 +1,66 @@
+<?php
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\Thumbro\Tests\Unit\Linker;
+
+use MediaWiki\Extension\Thumbro\Linker\CrawlerAnchor;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Thumbro\Linker\CrawlerAnchor
+ */
+class CrawlerAnchorTest extends MediaWikiUnitTestCase {
+
+	/**
+	 * Exact-markup pin. Both emitting paths (toHtml and the Parsoid injector) route
+	 * through here, so this is the single place the anchor's shape is guarded. None of
+	 * these attributes has a visible effect, so nothing else would catch their removal.
+	 */
+	public function testBuildsInertCrawlerAnchor(): void {
+		$this->assertSame(
+			'<a href="/w/images/9/90/Foo.png" class="mw-file-source" tabindex="-1"'
+				. ' aria-hidden="true"><!-- Image link for Crawlers --></a>',
+			CrawlerAnchor::build( '/w/images/9/90/Foo.png' )
+		);
+	}
+
+	/**
+	 * aria-hidden is not one of Html's boolean attributes, so a PHP bool would render the
+	 * invalid aria-hidden="1" — a silent failure with no other symptom.
+	 */
+	public function testAriaHiddenIsTheStringTrue(): void {
+		$html = CrawlerAnchor::build( '/x.png' );
+
+		$this->assertStringContainsString( 'aria-hidden="true"', $html );
+		$this->assertStringNotContainsString( 'aria-hidden="1"', $html );
+	}
+
+	/**
+	 * The anchor must never gain an accessible name: it is out of the accessibility tree,
+	 * and a name would also mean shipping an untranslated string.
+	 */
+	public function testHasNoAccessibleName(): void {
+		$html = CrawlerAnchor::build( '/x.png' );
+
+		$this->assertStringNotContainsString( 'title=', $html );
+		$this->assertStringNotContainsString( 'View source image', $html );
+	}
+
+	public function testEscapesTheUrl(): void {
+		$html = CrawlerAnchor::build( '/w/images/a/ab/Foo"bar&baz.png' );
+
+		$this->assertStringContainsString( '&quot;', $html );
+		$this->assertStringContainsString( '&amp;', $html );
+		$this->assertStringNotContainsString( '"bar', $html );
+	}
+
+	/**
+	 * The stripper and the injector's idempotency check both key on this token.
+	 */
+	public function testClassNameMatchesTheEmittedMarkup(): void {
+		$this->assertStringContainsString(
+			'class="' . CrawlerAnchor::CLASS_NAME . '"',
+			CrawlerAnchor::build( '/x.png' )
+		);
+	}
+}


### PR DESCRIPTION
## Problem

Parsoid builds the media DOM itself and never calls `ThumbroThumbnailImage::toHtml()` — `DataAccess::getFileInfo()` calls `$file->transform()` but reads only scalars. Under Parsoid read views the crawler anchor is therefore absent and T54647 fully regresses: the original-resolution URL appears **nowhere** in the page.

Verified on a live wiki, same wikitext, both parsers. Every Parsoid image URL is under `/thumb/`, and both `href` and `resource` point at the File *description page*, not the file. T54647 puts it plainly: *"Google will never get to find out that the original image files exist."*

Thumbnail **generation** is unaffected — that runs off `File::transform()` via `BitmapHandlerTransform`, which Parsoid does call. Only the HTML shaping was lost.

## Fix

A Parsoid DOM processor registered via `ParsoidModules`, running in the `extpp` pass after `AddMediaInfo`.

It works on the live DOM inside the parse, so the cost is paid once per parse rather than on every view — most wikis have no edge or file cache in front of them. Doing this as a post-parse hook instead would mean re-parsing the cached HTML and re-serializing it, which puts `data-parsoid`/`data-mw` at risk and couples the extension to Parsoid document APIs that differ across REL1_43–46. The DOM processor has neither problem: Parsoid owns the document throughout.

Three decisions worth calling out:

**Keyed on the img's `resource`, not `a.mw-file-description`.** Parsoid sets `resource` on every media element, but the description anchor exists on only three of the five media shapes — `link=Page` has a different anchor and `link=` has none. Keying on the description anchor would silently miss 40% of images.

**`typeof` matched as a token, not a prefix.** It is multi-valued and Parsoid *prepends*, so template-generated media reads `mw:Transclusion mw:File/Thumb`. A `str_starts_with` test would miss every infobox image on the wiki.

**The anchor goes after the media wrapper, never as the container's first child.** `MediaStructure::parse()` takes the first non-separator child as the link element; an anchor there makes it return null, `figureHandler()` emit nothing, and the image **silently disappear from wikitext on save**. A test asserts this for every shape.

Legacy keeps its own structural emission in `toHtml()` — it has the `File` object at construction time, whereas legacy output carries no `resource` on the img for the `link=`/`link=Page` forms, so the two parsers cannot share one pass. `CrawlerAnchor` holds the attributes and comment text both paths build from.

## Verification

**Rendering** — live wiki, thumb / `link=` / `link=Page`, plus `<gallery>`, `mode="packed"` and `mode="slideshow"`:

```
legacy           mw-file-element=8  mw-file-source=8
?useparsoid=1    mw-file-element=8  mw-file-source=8
anchor href -> HTTP 200 image/png
```

Galleries nest two levels deeper than the inline shapes (`li.gallerybox > div.thumb > span[typeof="mw:File"]`), and their `<ul>` carries `typeof="mw:Extension/gallery"` — a test asserts each anchor's parent is the media span, so one anchor belongs to each image rather than one to a whole gallery.

**VisualEditor** — saved through the real Save UI on a page with a thumb, `link=`, `link=Page` and a packed gallery. MediaWiki's own diff of the resulting revision:

```
  Outro paragraph.          Outro paragraph.
                          + SAVED-VIA-VE
```

Only the intended line; every media form byte-identical. VE's regenerated DOM contains none of these anchors — it drops them — but the serializer reconstructs the wikitext from `data-parsoid`, so there is no dirty diff. The saved page re-renders with all anchors intact.

**Checks** — `composer preflight` green: parallel-lint, PHPCS no warnings, minus-x, Phan, PHPUnit 213 tests / 418 assertions. CI green across REL1_43, REL1_44, REL1_45, REL1_46 and master.

## Limits

- Uses Parsoid's `Ext\DOMProcessor` API. A supported extension point — Cite, ImageMap, Poem and SyntaxHighlight all register `ParsoidModules` — but it moves with Parsoid.
- At parse time `resource` arrives in its relative spec form (`./File:X.png`); the absolute URLs visible in rendered markup are a later expansion step. The processor handles the relative form only, which is what it actually receives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYtMioqiBfF9mc8z2BMVH6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hidden links to original-resolution media files for crawler discovery.
  * Supported thumbnails, galleries, linked media, and template-generated media.
  * Ensured links are safely escaped, inert, and not exposed to assistive technologies.

* **Bug Fixes**
  * Prevented duplicate or broken links when media files cannot be resolved.
  * Preserved captions and media layout during processing.

* **Tests**
  * Added coverage for supported media formats, accessibility attributes, URL escaping, idempotency, and missing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->